### PR TITLE
Develop 0.9.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+notes.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 notes.txt
+temp.pine

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 notes.txt
 temp.pine
+temp2.pine

--- a/KOndulat.pine
+++ b/KOndulat.pine
@@ -42,7 +42,8 @@ tcol = input.color(defval=color.green, title=" ", inline="option6", group="Wave 
 twid = input.int(defval=2, title="Width", inline="option6", group="Wave options")
 
 ichi = input.bool(defval=false, title="Ichimoku Kinko Hyo", inline="option1", group="Ichimoku options")
-crss = input.bool(defval=false, title="Tenkan Crossover/under markers", inline="option2", group="Ichimoku options")
+crss = input.bool(defval=false, title="Tenkan Crossover/under markers.", inline="option2", group="Ichimoku options")
+maxl = input.int(10, minval=1, title=" up to", inline="option2", group="Ichimoku options", tooltip = "An indicator is limited in the allowed amount of labels to draw. Keep this value low enough to prevent having lost labels.")
 
 ksmx = input.int(defval=42, title="Max period", inline="option1", group="Kihon Suchi options", tooltip = "Won't draw Ichimoku times after this elapsed period")
 kisu = input.bool(defval=false, title="from last Crossover", inline="option1", group="Kihon Suchi options", tooltip = "Need Tenkan crossovers to be displayed to add predictions")
@@ -116,7 +117,6 @@ conversionPeriods = input.int(9, minval=1, title="Conversion Line Length", group
 basePeriods = input.int(26, minval=1, title="Base Line Length", group="Ichimoku")
 laggingSpan2Periods = input.int(52, minval=1, title="Leading Span B Length", group="Ichimoku")
 displacement = input.int(26, minval=1, title="Lagging Span", group="Ichimoku")
-MaxLabels = input.int(7, minval=1, title="Maximum Crossover Labels", group="Ichimoku", tooltip = "An indicator is limited in the allowed amount of labels to draw. Keep this value low enough to prevent having lost labels.")
 conversionLine = donchian(conversionPeriods)
 baseLine = donchian(basePeriods)
 leadLine1 = math.avg(conversionLine, baseLine)
@@ -146,20 +146,6 @@ src = input(close, title="Source", group="Exponential Moving Average")
 offset = input.int(title="Offset", defval=0, minval=-500, maxval=500, display = display.data_window, group="Exponential Moving Average")
 typeMA = input.string(title = "Method", defval = "SMA", options=["SMA", "EMA", "SMMA (RMA)", "WMA", "VWMA"], group="Exponential Moving Average", display = display.data_window)
 smoothingLength = input.int(title = "Length", defval = 5, minval = 1, maxval = 100, group="Exponential Moving Average", display = display.data_window)
-
-// ma(source, length, type) =>
-//     switch type
-//         "SMA" => ta.sma(source, length)
-//         "EMA" => ta.ema(source, length)
-//         "SMMA (RMA)" => ta.rma(source, length)
-//         "WMA" => ta.wma(source, length)
-//         "VWMA" => ta.vwma(source, length)
-
-_barForTime(_t) =>
-    var int _bar = na
-    if time_close[1] <= _t and time >= _t
-        _bar := bar_index
-    _bar
 
 int nb_seconds = timeframe.in_seconds(timeframe.period)
 int candleTime = nb_seconds * 1000
@@ -700,7 +686,7 @@ if crss and barstate.islastconfirmedhistory
         int v = array.get(crossoverBars, i)
         int d = array.get(crossoverDist, i)
         labelCount := labelCount + 1
-        if labelCount <= MaxLabels
+        if labelCount <= maxl
             if i == array.size(crossoverBars) - 1
                 label.new(v, na, "⬅ " + str.format("{0, number, ###}", d) + "\n→" + str.format("{0, number, ###}", 1 + bar_index - lastCrossover), xloc.bar_index, yloc.abovebar, color.rgb(255, 0, 0), label.style_arrowdown, color.rgb(117, 188, 255), size.normal)
             else    

--- a/KOndulat.pine
+++ b/KOndulat.pine
@@ -3,7 +3,7 @@ indicator("Kir Ondulatoire", shorttitle="KOndulat", overlay=true)
 
     // version 0.9.4
 
-    // Copyright (C) 2024  Kir
+    // Copyright (C) 2024  Kir (https://github.com/Kirken2004/tv-kir-ondulat)
 
     // This program is free software; you can redistribute it and/or modify
     // it under the terms of the GNU General Public License as published by
@@ -28,6 +28,8 @@ x2Input = input.time(TIME_DEFAULT,   "Point B", inline = "2", confirm = true)
 y2Input = input.price(PRICE_DEFAULT, "",        inline = "2", tooltip = "Pick point B", confirm = true)
 x3Input = input.time(TIME_DEFAULT,   "Point C", inline = "3", confirm = true)
 y3Input = input.price(PRICE_DEFAULT, "",        inline = "3", tooltip = "Pick point C", confirm = true)
+x4Input = input.time(TIME_DEFAULT,   "Point D", inline = "4", confirm = true)
+y4Input = input.price(PRICE_DEFAULT, "",        inline = "4", tooltip = "Pick point D (place before C to ignore)", confirm = true)
 
 mult = input.bool(defval=false, title="Multiples E/N", inline="option1", group="Miscellaneous options")
 fibo = input.bool(defval=false, title="Fibonacci Axis", inline="option2", group="Miscellaneous options")
@@ -48,10 +50,12 @@ type Wave
     int   time2
     int   time3
     int   time4
+    int   time5
     float price1
     float price2
     float price3
     float price4
+    float price5
     color lineColor
     color arrowColor1
     color arrowColor2
@@ -65,6 +69,8 @@ type Wave
     float pcChange2
     int   boxTime0
     int   boxTime1
+    int   boxTime2
+    int   boxTime3
     float boxTopPrice
     float boxTopPrice2
     float boxTopPrice3
@@ -72,6 +78,9 @@ type Wave
     float boxTopPrice5
     float boxVPrice
     float boxNtPrice
+    float boxPPrice
+    float boxPriceDTop
+    float boxPriceDBot
     float currentPrice
     int   currentTime
     int   barWidthInPixels
@@ -149,6 +158,7 @@ var labelTargetPriceE = label.new(x=na, y=na, text="E= na", color=color.rgb(120,
 var labelTargetPriceN = label.new(x=na, y=na, text="N= na", color=color.rgb(120, 123, 134, 90), textcolor=color.orange, style=label.style_label_left, xloc=xloc.bar_time)
 var labelTargetPriceV = label.new(x=na, y=na, text="V= na", color=color.rgb(120, 123, 134, 90), textcolor=color.rgb(255, 82, 102), style=label.style_label_left, xloc=xloc.bar_time)
 var labelTargetPriceNt = label.new(x=na, y=na, text="NT= na", color=color.rgb(120, 123, 134, 90), textcolor=color.green, style=label.style_label_left, xloc=xloc.bar_time)
+var labelTargetPriceP = label.new(x=na, y=na, text="P= na", color=color.rgb(120, 123, 134, 90), textcolor=color.lime, style=label.style_label_left, xloc=xloc.bar_time)
 
 var labelTargetPrice2E = label.new(x=na, y=na, text="2E: na", color=color.rgb(120, 123, 134, 90), textcolor=color.blue, style=label.style_label_left, xloc=xloc.bar_time)
 var labelTargetPrice2N = label.new(x=na, y=na, text="2N: na", color=color.rgb(120, 123, 134, 90), textcolor=color.orange, style=label.style_label_left, xloc=xloc.bar_time)
@@ -158,6 +168,11 @@ var labelTargetPrice4E = label.new(x=na, y=na, text="4E: na", color=color.rgb(12
 var labelTargetPrice4N = label.new(x=na, y=na, text="4N: na", color=color.rgb(120, 123, 134, 90), textcolor=color.orange, style=label.style_label_left, xloc=xloc.bar_time)
 var labelTargetPrice5E = label.new(x=na, y=na, text="4E: na", color=color.rgb(120, 123, 134, 90), textcolor=color.blue, style=label.style_label_left, xloc=xloc.bar_time)
 var labelTargetPrice5N = label.new(x=na, y=na, text="4N: na", color=color.rgb(120, 123, 134, 90), textcolor=color.orange, style=label.style_label_left, xloc=xloc.bar_time)
+
+var labelTargetPriceETop = label.new(x=na, y=na, text="Emax", color=color.rgb(120, 123, 134, 90), textcolor=color.aqua, style=label.style_label_left, xloc=xloc.bar_time)
+var labelTargetPriceEBot = label.new(x=na, y=na, text="Emin", color=color.rgb(120, 123, 134, 90), textcolor=color.aqua, style=label.style_label_left, xloc=xloc.bar_time)
+var labelBeforeTargetETime = label.new(x=na, y=na, text="Test", color=color.rgb(0, 137, 123, 48), textcolor=color.rgb(255, 255, 255, 34), style=label.style_label_up, xloc=xloc.bar_time, size=size.small)
+var labelAfterTargetETime = label.new(x=na, y=na, text="Test", color=color.rgb(0, 137, 123, 48), textcolor=color.rgb(255, 255, 255, 34), style=label.style_label_up, xloc=xloc.bar_time, size=size.small)
 
 var labelFiboTextColor = color.teal
 var labelFiboTextColorNeg = color.rgb(0, 104, 93)
@@ -195,6 +210,7 @@ drawIndicator(Wave t) =>
     line.new(t.boxTime0, t.boxTopPrice, t.boxTime1, t.boxTopPrice, xloc = xloc.bar_time, color = t.arrowColor2, width=1, style=line.style_dotted)                                                                                   // level E
     line.new(t.boxTime0, t.boxVPrice, t.boxTime1, t.boxVPrice, xloc = xloc.bar_time, color = t.arrowColor3, width=1, style=line.style_dotted)                                                                                       // level V
     line.new(t.boxTime0, t.boxNtPrice, t.boxTime1, t.boxNtPrice, xloc = xloc.bar_time, color = t.arrowColor4, width=1, style=line.style_dotted)                                                                                     // level Nt
+    line.new(t.boxTime0, t.boxPPrice, t.boxTime1, t.boxPPrice, xloc = xloc.bar_time, color = t.arrowColor4, width=1, style=line.style_dotted)                                                                                       // level P
     
     if mult
         line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxTopPrice2, xloc = xloc.bar_time, color = t.arrowColor2, width=1, style=line.style_arrow_right)                                                                         // blue arrow 2E (highest)
@@ -216,6 +232,7 @@ drawIndicator(Wave t) =>
 
     line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxVPrice, xloc = xloc.bar_time, color = t.arrowColor3, width=1, style=line.style_arrow_right)                                                                            // red arrow V
     line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxNtPrice, xloc = xloc.bar_time, color = t.arrowColor4, width=1, style=line.style_arrow_right)                                                                           // green arrow Nt (lowest)
+    line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxPPrice, xloc = xloc.bar_time, color = t.arrowColor4, width=1, style=line.style_arrow_right)                                                                           // lime arrow P
     line.new(t.time3 + t.timeDelta2 - nb_seconds, t.price3, t.time3 + t.timeDelta2 - nb_seconds, t.boxTopPrice, xloc = xloc.bar_time, color = t.arrowColor3, width=1, style=line.style_dashed)                                      // dashed at double correction time
 
     box.new(t.boxTime0, t.boxTopPrice, t.boxTime1, t.price3, border_color = color.teal, border_width = 1, border_style = line.style_solid, bgcolor = na, xloc=xloc.bar_time)                                                        // target box deadline
@@ -236,8 +253,8 @@ drawIndicator(Wave t) =>
 
     // Wave labels
     label.new(t.time1, t.price1, "A", xloc.bar_time, yloc.price, pointFillColor, styleABC, pointTextColor, size.small, text.align_center)
-    label.new(t.time2, t.price2, "B\n" + str.format("{0, number, ###}", (t.time2 - t.time1) / nb_seconds / 1000), xloc.bar_time, yloc.price, pointFillColor, styleABC2, pointTextColor, size.small, text.align_center)
-    label.new(t.time3, t.price3, "C\n" + str.format("{0, number, ###}", (t.time3 - t.time1) / nb_seconds / 1000), xloc.bar_time, yloc.price, pointFillColor, styleABC, pointTextColor, size.small, text.align_center)
+    label.new(t.time2, t.price2, "B\n" + str.format("{0, number, ###}", 1 + ((t.time2 - t.time1) / nb_seconds / 1000)), xloc.bar_time, yloc.price, pointFillColor, styleABC2, pointTextColor, size.small, text.align_center)
+    label.new(t.time3, t.price3, "C\n" + str.format("{0, number, ###}", 1 + ((t.time3 - t.time1 + 1.001) / nb_seconds / 1000)), xloc.bar_time, yloc.price, pointFillColor, styleABC, pointTextColor, size.small, text.align_center)
 
     // Compute tenth (deciles) of the box duration
     priceDeci = (t.price4 - t.price3) / 10
@@ -253,7 +270,7 @@ drawIndicator(Wave t) =>
     if t.price2 < t.price1
         labelRetracementBC.set_y(t.price2 + (1.8 * math.abs(t.price3 - t.price2)))
     labelRetracementBC.set_yloc(yloc.price)
-    labelRetracementBC.set_text("retracement BC: " + str.format("{0, number, ##.##}", retracementBC) + "%")
+    labelRetracementBC.set_text("retracement BC: " + str.format("{0, number, #.##}", retracementBC) + "%")
 
     // Box date labels
     if (t.price1 > t.price2)
@@ -295,6 +312,11 @@ drawIndicator(Wave t) =>
     labelTargetPriceNt.set_y(t.boxNtPrice)
     labelTargetPriceNt.set_yloc(yloc.price)
     labelTargetPriceNt.set_text("NT=" + str.format("{0, number, #.##}", t.boxNtPrice))
+
+    labelTargetPriceP.set_x(t.boxTime1)
+    labelTargetPriceP.set_y(t.boxPPrice)
+    labelTargetPriceP.set_yloc(yloc.price)
+    labelTargetPriceP.set_text("P=" + str.format("{0, number, #.##}", t.boxPPrice))
         
     if mult
         labelTargetPrice2E.set_x(t.boxTime1)
@@ -336,6 +358,29 @@ drawIndicator(Wave t) =>
         labelTargetPrice5N.set_y(t.boxTopPrice5 - (t.boxTopPrice - t.price4))
         labelTargetPrice5N.set_yloc(yloc.price)
         labelTargetPrice5N.set_text("5N=" + str.format("{0, number, #.##}", t.boxTopPrice5 - (t.boxTopPrice - t.price4)))
+
+    // If Point D has been placed after Point C, we have some prediction to make
+    if t.time5 > t.time3
+        box.new(t.boxTime2, t.boxPriceDBot, t.boxTime3, t.boxPriceDTop, bgcolor = color.rgb(0,0,0,100), border_color = color.aqua, xloc = xloc.bar_time, border_width = 1)
+        line.new(t.time5, t.price5, t.boxTime2, t.boxPriceDTop, xloc=xloc.bar_time, color=color.aqua, style = line.style_arrow_right, width=1)
+        line.new(t.time5, t.price5, t.boxTime3, t.boxPriceDTop, xloc=xloc.bar_time, color=color.aqua, style = line.style_arrow_right, width=1)
+        label.new(t.time5, t.price5, "D\n" + str.format("{0, number, ###}", 1 + ((t.time5 - t.time1) / nb_seconds / 1000)) + "\n" + str.format("{0, number, #.##}", t.price5), xloc.bar_time, yloc.price, pointFillColor, styleABC2, pointTextColor, size.small, text.align_center)
+        labelTargetPriceETop.set_x(t.boxTime3)
+        labelTargetPriceETop.set_y(t.boxPriceDTop)
+        labelTargetPriceETop.set_yloc(yloc.price)
+        labelTargetPriceETop.set_text(str.format("{0, number, #.##}", t.boxPriceDTop))        
+        labelTargetPriceEBot.set_x(t.boxTime3)
+        labelTargetPriceEBot.set_y(t.boxPriceDBot)
+        labelTargetPriceEBot.set_yloc(yloc.price)
+        labelTargetPriceEBot.set_text(str.format("{0, number, #.##}", t.boxPriceDBot))
+        labelBeforeTargetETime.set_x(t.boxTime2)
+        labelBeforeTargetETime.set_y(t.boxPriceDBot)
+        labelBeforeTargetETime.set_yloc(yloc.price)
+        labelBeforeTargetETime.set_text(str.format_time(t.boxTime2, 'dd-MMM-yyyy\nHH:mm:ss', "UTC+2"))
+        labelAfterTargetETime.set_x(t.boxTime3)
+        labelAfterTargetETime.set_y(t.boxPriceDBot)
+        labelAfterTargetETime.set_yloc(yloc.price)
+        labelAfterTargetETime.set_text(str.format_time(t.boxTime3, 'dd-MMM-yyyy\nHH:mm:ss', "UTC+2"))        
 
     if fibo
         var offsetXFiboM = (nb_seconds * 1000 * fiboBarOffset) + t.time2
@@ -453,10 +498,12 @@ if barstate.islastconfirmedhistory
     wave.time2  := x2Input
     wave.time3  := x3Input
     wave.time4  := x3Input + (x2Input - x1Input)
+    wave.time5  := x4Input
     wave.price1 := y1Input
     wave.price2 := y2Input
     wave.price3 := y3Input
-    wave.price4 := y3Input + (y2Input - y1Input)
+    wave.price4 := y3Input + (y2Input - y1Input)                                // N:   
+    wave.price5 := y4Input
     wave.lineColor := color.rgb(255, 255, 255, 66)
     wave.arrowColor1 := color.orange
     wave.arrowColor2 := color.blue
@@ -473,10 +520,15 @@ if barstate.islastconfirmedhistory
     wave.boxTopPrice := (wave.price2 - wave.price1) + wave.price2               // E:  BD = AB
     wave.boxVPrice := (wave.price2 - wave.price3) + wave.price2                 // V:  CD = BC
     wave.boxNtPrice := (wave.price3 - wave.price1) + wave.price3                // Nt: CD = AC (need 33% retracement of BC over AB)
-    wave.boxTopPrice2 := 2 * (wave.boxTopPrice - wave.price3) + wave.price3
-    wave.boxTopPrice3 := 3 * (wave.boxTopPrice - wave.price3) + wave.price3
-    wave.boxTopPrice4 := 4 * (wave.boxTopPrice - wave.price3) + wave.price3
-    wave.boxTopPrice5 := 5 * (wave.boxTopPrice - wave.price3) + wave.price3
+    wave.boxPPrice := (wave.price1 - wave.price3) + wave.price2                 // P:  CD = B + (A - C)
+    wave.boxTopPrice2 := 2 * (wave.price4 - wave.price3) + (wave.boxTopPrice - wave.price4) + wave.price3
+    wave.boxTopPrice3 := 3 * (wave.price4 - wave.price3) + (wave.boxTopPrice - wave.price4) + wave.price3
+    wave.boxTopPrice4 := 4 * (wave.price4 - wave.price3) + (wave.boxTopPrice - wave.price4) + wave.price3
+    wave.boxTopPrice5 := 5 * (wave.price4 - wave.price3) + (wave.boxTopPrice - wave.price4) + wave.price3
+    wave.boxPriceDBot := (wave.price5 - wave.price1) * 0.5 + wave.price1
+    wave.boxPriceDTop := wave.boxPriceDBot + (wave.price5 - (wave.boxTopPrice2 - (wave.boxTopPrice - wave.price4)))             // Bot + (D - 2N)
+    wave.boxTime2 := (wave.time5 - wave.time3) + wave.time5
+    wave.boxTime3 := (wave.time5 - wave.time1) + wave.time5
     wave.barWidthInPixels := math.abs(bar_index - bar_index[1])
 
     drawIndicator(wave)

--- a/KOndulat.pine
+++ b/KOndulat.pine
@@ -31,13 +31,16 @@ y3Input = input.price(PRICE_DEFAULT, "",        inline = "3", tooltip = "Pick po
 x4Input = input.time(TIME_DEFAULT,   "Point D", inline = "4", confirm = true)
 y4Input = input.price(PRICE_DEFAULT, "",        inline = "4", tooltip = "Pick point D (place before C to ignore)", confirm = true)
 
-mult = input.bool(defval=false, title="Multiples E/N", inline="option1", group="Miscellaneous options")
+mult = input.bool(defval=false, title="Multiples of E/N waves", inline="option1", group="Miscellaneous options")
 fibo = input.bool(defval=false, title="Fibonacci Axis", inline="option2", group="Miscellaneous options")
-tend = input.bool(defval=false, title="Stupid Linear Dir", inline="option3", group="Miscellaneous options")
-kisu = input.bool(defval=false, title="Kihon Sushi reminder", inline="option4", group="Miscellaneous options", tooltip = "Need Tenkan crossovers to be displayed to add predictions")
-ichi = input.bool(defval=false, title="Draw Ichimoku", inline="option5", group="Miscellaneous options")
-crss = input.bool(defval=false, title="Display Tenkan Crossover Cycles", inline="option6", group="Miscellaneous options")
-dema = input.bool(defval=false, title="Draw EMA", inline="options7", group="Miscellaneous options")
+tend = input.bool(defval=false, title="Straight Linear Projection", inline="option3", group="Miscellaneous options")
+kisu = input.bool(defval=false, title="Kihon Suchi series", inline="option4", group="Miscellaneous options", tooltip = "Need Tenkan crossovers to be displayed to add predictions")
+ichi = input.bool(defval=false, title="Ichimoku Kinko Hyo", inline="option5", group="Miscellaneous options")
+crss = input.bool(defval=false, title="Tenkan Crossover Markers", inline="option6", group="Miscellaneous options")
+dema = input.bool(defval=false, title="EMA", inline="options7", group="Miscellaneous options")
+labp = input.bool(defval=false, title="Prices in labels", inline="options8", group="Miscellaneous options")
+tren = input.bool(defval=false, title="Wave Trend Lines", inline="options9", group="Miscellaneous options", tooltip = "Only visibles if D label is also visible. Help to visually confirm if ABCD is an N/Y/P wave.")
+ac26 = input.bool(defval=false, title="26 periods after A/C", inline="options10", group="Miscellaneous options", tooltip = "The Kumo cloud between those two deadlines gives an active area to keep an eye on. Up to you to draw a bounding box there.")
 
 int realtimeTime = 1
 float realtimePrice = 1.0
@@ -50,12 +53,12 @@ type Wave
     int   time2
     int   time3
     int   time4
-    int   time5
+    int   timeD
     float price1
     float price2
     float price3
     float price4
-    float price5
+    float priceD
     color lineColor
     color arrowColor1
     color arrowColor2
@@ -65,12 +68,10 @@ type Wave
     float priceDelta2
     int   timeDelta1
     int   timeDelta2
-    float pcChange1
-    float pcChange2
     int   boxTime0
     int   boxTime1
-    int   boxTime2
-    int   boxTime3
+    int   boxTimeE0
+    int   boxTimeE1
     float boxTopPrice
     float boxTopPrice2
     float boxTopPrice3
@@ -79,11 +80,15 @@ type Wave
     float boxVPrice
     float boxNtPrice
     float boxPPrice
-    float boxPriceDTop
-    float boxPriceDBot
+    float boxPriceETop
+    float boxPriceEBot
     float currentPrice
+    float midADPrice
     int   currentTime
     int   barWidthInPixels
+    bool  nWave
+    bool  pWave
+    bool  yWave
 
 // Fibonacci stuff
 fiboBarWidth = input.int(2, minval=-1000, maxval=1000, title="Fibo width in bars", group="Fibonacci Axis", tooltip = "Due to the lack of scale/zoom detection, the width of the graduations is expressed in a multiplier of bar width")
@@ -95,7 +100,7 @@ conversionPeriods = input.int(9, minval=1, title="Conversion Line Length", group
 basePeriods = input.int(26, minval=1, title="Base Line Length", group="Ichimoku")
 laggingSpan2Periods = input.int(52, minval=1, title="Leading Span B Length", group="Ichimoku")
 displacement = input.int(26, minval=1, title="Lagging Span", group="Ichimoku")
-MaxLabels = input.int(15, minval=1, title="Maximum Crossover Labels", group="Ichimoku", tooltip = "An indicator is limited in the allowed amount of labels to draw. Keep this value low enough to prevent having lost labels.")
+MaxLabels = input.int(7, minval=1, title="Maximum Crossover Labels", group="Ichimoku", tooltip = "An indicator is limited in the allowed amount of labels to draw. Keep this value low enough to prevent having lost labels.")
 conversionLine = donchian(conversionPeriods)
 baseLine = donchian(basePeriods)
 leadLine1 = math.avg(conversionLine, baseLine)
@@ -139,13 +144,6 @@ _barForTime(_t) =>
     if time_close[1] <= _t and time >= _t
         _bar := bar_index
     _bar
-
-nBar1 = _barForTime(x1Input)
-nBar2 = _barForTime(x2Input)
-deltaBar1 = nBar2 - nBar1
-
-calculatePercentageChange(highPrice, lowPrice) =>
-    ((highPrice - lowPrice) / lowPrice) * 100
 
 nb_seconds = timeframe.in_seconds(timeframe.period)
 
@@ -204,17 +202,27 @@ var labelFiboN100 = label.new(x=na, y=na, text=" -100 %", color=color.rgb(120, 1
 drawIndicator(Wave t) =>
 
     // Wave lines, Box and Arrows
-    line.new(t.time1, t.price1, t.time2, t.price2, xloc = xloc.bar_time, color = t.lineColor, width=3, style=line.style_dotted)                                                                                                     // dotted impulse
-    line.new(t.time2, t.price2, t.time3, t.price3, xloc = xloc.bar_time, color = t.lineColor, width=3, style=line.style_dotted)                                                                                                     // dotted correction
-    line.new(t.time3, t.price3, t.time5, t.price5, xloc = xloc.bar_time, color = t.lineColor, width=3, style=line.style_dotted)                                                                                                     // dotted D wave
-    line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.price3 + t.priceDelta1, xloc = xloc.bar_time, color = t.arrowColor1, width=1, style=line.style_arrow_right)                                                               // orange arrow N (prime)
-    line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxTopPrice, xloc = xloc.bar_time, color = t.arrowColor2, width=1, style=line.style_arrow_right)                                                                          // blue arrow E (highest)
-    line.new(t.boxTime0, t.price4, t.boxTime1, t.price4, xloc = xloc.bar_time, color = t.arrowColor1, width=1, style=line.style_dotted)                                                                                             // level N
-    line.new(t.boxTime0, t.boxTopPrice, t.boxTime1, t.boxTopPrice, xloc = xloc.bar_time, color = t.arrowColor2, width=1, style=line.style_dotted)                                                                                   // level E
-    line.new(t.boxTime0, t.boxVPrice, t.boxTime1, t.boxVPrice, xloc = xloc.bar_time, color = t.arrowColor3, width=1, style=line.style_dotted)                                                                                       // level V
-    line.new(t.boxTime0, t.boxNtPrice, t.boxTime1, t.boxNtPrice, xloc = xloc.bar_time, color = t.arrowColor4, width=1, style=line.style_dotted)                                                                                     // level Nt
-    line.new(t.boxTime0, t.boxPPrice, t.boxTime1, t.boxPPrice, xloc = xloc.bar_time, color = t.arrowColor4, width=1, style=line.style_dotted)                                                                                       // level P
+    line.new(t.time1, t.price1, t.time2, t.price2, xloc = xloc.bar_time, color = t.lineColor, width=3, style=line.style_dotted)                                                                                                         // dotted impulse
+    line.new(t.time2, t.price2, t.time3, t.price3, xloc = xloc.bar_time, color = t.lineColor, width=3, style=line.style_dotted)                                                                                                         // dotted correction
+    line.new(t.time3, t.price3, t.timeD, t.priceD, xloc = xloc.bar_time, color = t.lineColor, width=3, style=line.style_dotted)                                                                                                         // dotted D wave
+    line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.price3 + t.priceDelta1, xloc = xloc.bar_time, color = t.arrowColor1, width=1, style=line.style_arrow_right)                                                                   // orange arrow N (prime)        C+(B-A)
+    line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxTopPrice, xloc = xloc.bar_time, color = t.arrowColor2, width=1, style=line.style_arrow_right)                                                                              // blue arrow E (highest/lowest) B+(B-A)
+    line.new(t.boxTime0, t.price4, t.boxTime1, t.price4, xloc = xloc.bar_time, color = t.arrowColor1, width=1, style=line.style_dotted)                                                                                                 // level N
+    line.new(t.boxTime0, t.boxTopPrice, t.boxTime1, t.boxTopPrice, xloc = xloc.bar_time, color = t.arrowColor2, width=1, style=line.style_dotted)                                                                                       // level E
+    line.new(t.boxTime0, t.boxVPrice, t.boxTime1, t.boxVPrice, xloc = xloc.bar_time, color = t.arrowColor3, width=1, style=line.style_dotted)                                                                                           // level V
+    if t.pWave == false
+        line.new(t.boxTime0, t.boxNtPrice, t.boxTime1, t.boxNtPrice, xloc = xloc.bar_time, color = t.arrowColor4, width=1, style=line.style_dotted)                                                                                     // level Nt
+    if t.pWave
+        line.new(t.boxTime0, t.boxPPrice, t.boxTime1, t.boxPPrice, xloc = xloc.bar_time, color = t.arrowColor4, width=1, style=line.style_dotted)                                                                                       // level P
     
+    if ac26
+        int time1plus26 = t.time1 + (26 * nb_seconds * 1000)
+        int time3plus26 = t.time3 + (26 * nb_seconds * 1000)
+        float highest = math.max(t.price1, t.price2, t.price3, t.priceD, t.boxTopPrice)
+        float lowest = math.min(t.price1, t.price2, t.price3, t.priceD, t.boxTopPrice)
+        line.new(time1plus26, highest, time1plus26, lowest, xloc = xloc.bar_time, color = color.orange, width=1, style=line.style_dotted)                                                                                             // time A + 26 periods
+        line.new(time3plus26, highest, time3plus26, lowest, xloc = xloc.bar_time, color = color.orange, width=1, style=line.style_dotted)                                                                                             // time C + 26 periods
+
     if mult
         line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxTopPrice2, xloc = xloc.bar_time, color = t.arrowColor2, width=1, style=line.style_arrow_right)                                                                         // blue arrow 2E (highest)
         line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxTopPrice2 - (t.boxTopPrice - t.price4), xloc = xloc.bar_time, color = t.arrowColor1, width=1, style=line.style_arrow_right)                                            // orange arrow 2N (prime)
@@ -233,13 +241,15 @@ drawIndicator(Wave t) =>
         line.new(t.boxTime0, t.boxTopPrice5 - (t.boxTopPrice - t.price4), t.boxTime1, t.boxTopPrice5 - (t.boxTopPrice - t.price4), xloc = xloc.bar_time, color = t.arrowColor1, width=1, style=line.style_dotted)                       // level 5N
         line.new(t.boxTime0, t.boxTopPrice5, t.boxTime1, t.boxTopPrice5, xloc = xloc.bar_time, color = t.arrowColor2, width=1, style=line.style_dotted)                                                                                 // level 5E
 
-    line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxVPrice, xloc = xloc.bar_time, color = t.arrowColor3, width=1, style=line.style_arrow_right)                                                                            // red arrow V
-    line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxNtPrice, xloc = xloc.bar_time, color = t.arrowColor4, width=1, style=line.style_arrow_right)                                                                           // green arrow Nt (lowest)
-    line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxPPrice, xloc = xloc.bar_time, color = t.arrowColor4, width=1, style=line.style_arrow_right)                                                                           // lime arrow P
-    line.new(t.time3 + t.timeDelta2 - nb_seconds, t.price3, t.time3 + t.timeDelta2 - nb_seconds, t.boxTopPrice, xloc = xloc.bar_time, color = t.arrowColor3, width=1, style=line.style_dashed)                                      // dashed at double correction time
+    line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxVPrice, xloc = xloc.bar_time, color = t.arrowColor3, width=1, style=line.style_arrow_right)                                                                                // red arrow V      B+(B-C)
+    if t.pWave == false
+        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxNtPrice, xloc = xloc.bar_time, color = t.arrowColor4, width=1, style=line.style_arrow_right)                                                                           // green arrow Nt   C+(C-A)
+    if t.pWave
+        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxPPrice, xloc = xloc.bar_time, color = t.arrowColor4, width=1, style=line.style_arrow_right)                                                                            // lime arrow P
+    line.new(t.time3 + t.timeDelta2 - nb_seconds, t.price3, t.time3 + t.timeDelta2 - nb_seconds, t.boxTopPrice, xloc = xloc.bar_time, color = t.arrowColor3, width=1, style=line.style_dashed)                                          // dashed at double correction time
 
-    box.new(t.boxTime0, t.boxTopPrice, t.boxTime1, t.price3, border_color = color.teal, border_width = 1, border_style = line.style_solid, bgcolor = na, xloc=xloc.bar_time)                                                        // target box deadline
-    line.new(t.time3 + t.timeDelta1, t.boxTopPrice, t.time3 + t.timeDelta1, t.price3, xloc=xloc.bar_time, style = line.style_dashed, width = 1, color=color.teal)                                                                   // target dateline
+    box.new(t.boxTime0, t.boxTopPrice, t.boxTime1, t.price3, border_color = color.teal, border_width = 1, border_style = line.style_solid, bgcolor = na, xloc=xloc.bar_time)                                                          // target box deadline
+    line.new(t.time3 + t.timeDelta1, t.boxTopPrice, t.time3 + t.timeDelta1, t.price3, xloc=xloc.bar_time, style = line.style_dashed, width = 1, color=color.teal)                                                                     // target dateline
 
     // toggle the direction of things considering the relation between time A and time B
     var styleABC = label.style_label_up
@@ -255,9 +265,12 @@ drawIndicator(Wave t) =>
     pointFillColor = color.rgb(105, 155, 255)
 
     // Wave labels
-    label.new(t.time1, t.price1, "A", xloc.bar_time, yloc.price, pointFillColor, styleABC, pointTextColor, size.small, text.align_center)
-    label.new(t.time2, t.price2, "B\n" + str.format("{0, number, ###}", 1 + ((t.time2 - t.time1) / nb_seconds / 1000)), xloc.bar_time, yloc.price, pointFillColor, styleABC2, pointTextColor, size.small, text.align_center)
-    label.new(t.time3, t.price3, "C\n" + str.format("{0, number, ###}", 1 + ((t.time3 - t.time1 + 1.001) / nb_seconds / 1000)), xloc.bar_time, yloc.price, pointFillColor, styleABC, pointTextColor, size.small, text.align_center)
+    var textA = "A" + (labp ? "\n" + str.format("{0, number, #.##}", t.price1) : "")
+    var textB = "B\n" + str.format("{0, number, ###}", 1 + ((t.time2 - t.time1) / nb_seconds / 1000)) + (labp ? "\n" + str.format("{0, number, #.##}", t.price2) : "")
+    var textC = "C\n" + str.format("{0, number, ###}", 1 + ((t.time3 - t.time1 + 1.001) / nb_seconds / 1000)) + (labp ? "\n" + str.format("{0, number, #.##}", t.price3) : "")
+    label.new(t.time1, t.price1, textA, xloc.bar_time, yloc.price, pointFillColor, styleABC, pointTextColor, size.small, text.align_center)
+    label.new(t.time2, t.price2, textB, xloc.bar_time, yloc.price, pointFillColor, styleABC2, pointTextColor, size.small, text.align_center)
+    label.new(t.time3, t.price3, textC, xloc.bar_time, yloc.price, pointFillColor, styleABC, pointTextColor, size.small, text.align_center)
 
     // Compute tenth (deciles) of the box duration
     priceDeci = (t.price4 - t.price3) / 10
@@ -311,15 +324,17 @@ drawIndicator(Wave t) =>
     labelTargetPriceV.set_yloc(yloc.price)
     labelTargetPriceV.set_text("V=" + str.format("{0, number, #.##}", t.boxVPrice))
 
-    labelTargetPriceNt.set_x(t.boxTime1)
-    labelTargetPriceNt.set_y(t.boxNtPrice)
-    labelTargetPriceNt.set_yloc(yloc.price)
-    labelTargetPriceNt.set_text("NT=" + str.format("{0, number, #.##}", t.boxNtPrice))
+    if t.pWave == false
+        labelTargetPriceNt.set_x(t.boxTime1)
+        labelTargetPriceNt.set_y(t.boxNtPrice)
+        labelTargetPriceNt.set_yloc(yloc.price)
+        labelTargetPriceNt.set_text("NT=" + str.format("{0, number, #.##}", t.boxNtPrice))
 
-    labelTargetPriceP.set_x(t.boxTime1)
-    labelTargetPriceP.set_y(t.boxPPrice)
-    labelTargetPriceP.set_yloc(yloc.price)
-    labelTargetPriceP.set_text("P=" + str.format("{0, number, #.##}", t.boxPPrice))
+    if t.pWave
+        labelTargetPriceP.set_x(t.boxTime1)
+        labelTargetPriceP.set_y(t.boxPPrice)
+        labelTargetPriceP.set_yloc(yloc.price)
+        labelTargetPriceP.set_text("P=" + str.format("{0, number, #.##}", t.boxPPrice))
         
     if mult
         labelTargetPrice2E.set_x(t.boxTime1)
@@ -363,27 +378,33 @@ drawIndicator(Wave t) =>
         labelTargetPrice5N.set_text("5N=" + str.format("{0, number, #.##}", t.boxTopPrice5 - (t.boxTopPrice - t.price4)))
 
     // If Point D has been placed after Point C, we have some prediction to make
-    if t.time5 > t.time3
-        box.new(t.boxTime2, t.boxPriceDBot, t.boxTime3, t.boxPriceDTop, bgcolor = color.rgb(0,0,0,100), border_color = color.aqua, xloc = xloc.bar_time, border_width = 1)
-        line.new(t.time5, t.price5, t.boxTime2, t.boxPriceDTop, xloc=xloc.bar_time, color=color.aqua, style = line.style_arrow_right, width=1)
-        line.new(t.time5, t.price5, t.boxTime3, t.boxPriceDTop, xloc=xloc.bar_time, color=color.aqua, style = line.style_arrow_right, width=1)
-        label.new(t.time5, t.price5, "D\n" + str.format("{0, number, ###}", 1 + ((t.time5 - t.time1) / nb_seconds / 1000)) + "\n" + str.format("{0, number, #.##}", t.price5), xloc.bar_time, yloc.price, pointFillColor, styleABC2, pointTextColor, size.small, text.align_center)
-        labelTargetPriceETop.set_x(t.boxTime3)
-        labelTargetPriceETop.set_y(t.boxPriceDTop)
+    if t.timeD > t.time3
+        box.new(t.boxTimeE0, t.boxPriceEBot, t.boxTimeE1, t.boxPriceETop, bgcolor = color.rgb(0,0,0,100), border_color = color.aqua, xloc = xloc.bar_time, border_width = 1)
+        line.new(t.timeD, t.priceD, t.boxTimeE0, t.boxPriceETop, xloc=xloc.bar_time, color=color.aqua, style = line.style_arrow_right, width=1)
+        line.new(t.timeD, t.priceD, t.boxTimeE1, t.boxPriceETop, xloc=xloc.bar_time, color=color.aqua, style = line.style_arrow_right, width=1)
+        label.new(t.timeD, t.priceD, "D\n" + str.format("{0, number, ###}", 1 + ((t.timeD - t.time1) / nb_seconds / 1000)) + (labp ? "\n" + str.format("{0, number, #.##}", t.priceD) : ""), xloc.bar_time, yloc.price, pointFillColor, styleABC2, pointTextColor, size.small, text.align_center)
+        labelTargetPriceETop.set_x(t.boxTimeE1)
+        labelTargetPriceETop.set_y(t.boxPriceETop)
         labelTargetPriceETop.set_yloc(yloc.price)
-        labelTargetPriceETop.set_text(str.format("{0, number, #.##}", t.boxPriceDTop))        
-        labelTargetPriceEBot.set_x(t.boxTime3)
-        labelTargetPriceEBot.set_y(t.boxPriceDBot)
+        labelTargetPriceETop.set_text(str.format("{0, number, #.##}", t.boxPriceETop))        
+        labelTargetPriceEBot.set_x(t.boxTimeE1)
+        labelTargetPriceEBot.set_y(t.boxPriceEBot)
         labelTargetPriceEBot.set_yloc(yloc.price)
-        labelTargetPriceEBot.set_text(str.format("{0, number, #.##}", t.boxPriceDBot))
-        labelBeforeTargetETime.set_x(t.boxTime2)
-        labelBeforeTargetETime.set_y(t.boxPriceDBot)
+        labelTargetPriceEBot.set_text(str.format("{0, number, #.##}", t.boxPriceEBot))
+        labelBeforeTargetETime.set_x(t.boxTimeE0)
+        labelBeforeTargetETime.set_y(t.boxPriceEBot)
         labelBeforeTargetETime.set_yloc(yloc.price)
-        labelBeforeTargetETime.set_text(str.format_time(t.boxTime2, 'dd-MMM-yyyy\nHH:mm:ss', "UTC+2"))
-        labelAfterTargetETime.set_x(t.boxTime3)
-        labelAfterTargetETime.set_y(t.boxPriceDBot)
+        labelBeforeTargetETime.set_text(str.format_time(t.boxTimeE0, 'dd-MMM-yyyy\nHH:mm:ss', "UTC+2"))
+        labelAfterTargetETime.set_x(t.boxTimeE1)
+        labelAfterTargetETime.set_y(t.boxPriceEBot)
         labelAfterTargetETime.set_yloc(yloc.price)
-        labelAfterTargetETime.set_text(str.format_time(t.boxTime3, 'dd-MMM-yyyy\nHH:mm:ss', "UTC+2"))        
+        labelAfterTargetETime.set_text(str.format_time(t.boxTimeE1, 'dd-MMM-yyyy\nHH:mm:ss', "UTC+2"))        
+        if t.priceD < t.price3
+            labelBeforeTargetETime.set_style(label.style_label_down)
+            labelAfterTargetETime.set_style(label.style_label_down)
+        if tren
+            line.new(t.time1, t.price1, t.time3, t.price3, xloc=xloc.bar_time, color=color.green, style = line.style_solid, width=1, extend = extend.both)
+            line.new(t.time2, t.price2, t.timeD, t.priceD, xloc=xloc.bar_time, color=color.green, style = line.style_solid, width=1, extend = extend.both)
 
     if fibo
         var offsetXFiboM = (nb_seconds * 1000 * fiboBarOffset) + t.time2
@@ -509,12 +530,15 @@ if barstate.islastconfirmedhistory
     wave.time2  := x2Input
     wave.time3  := x3Input
     wave.time4  := x3Input + (x2Input - x1Input)
-    wave.time5  := x4Input
+    wave.timeD  := x4Input
     wave.price1 := y1Input
     wave.price2 := y2Input
     wave.price3 := y3Input
     wave.price4 := y3Input + (y2Input - y1Input)                                // N:   
-    wave.price5 := y4Input
+    wave.priceD := y4Input
+    wave.pWave  := ((wave.price1 > wave.price2 and wave.price3 < wave.price1 and wave.priceD > wave.price2) or (wave.price2 > wave.price1 and wave.price3 > wave.price1 and wave.priceD < wave.price2)) ? true : false
+    wave.yWave  := ((wave.price1 > wave.price2 and wave.price3 > wave.price1 and wave.priceD < wave.price2) or (wave.price2 > wave.price1 and wave.price3 < wave.price1 and wave.priceD > wave.price2)) ? true : false
+    wave.nWave  := (wave.pWave or wave.yWave) ? false : true
     wave.lineColor := color.rgb(255, 255, 255, 66)
     wave.arrowColor1 := color.orange
     wave.arrowColor2 := color.blue
@@ -524,8 +548,6 @@ if barstate.islastconfirmedhistory
     wave.priceDelta2 := y3Input - y2Input
     wave.timeDelta1 := x2Input - x1Input
     wave.timeDelta2 := x3Input - x2Input
-    wave.pcChange1 := calculatePercentageChange(y2Input, y1Input)
-    wave.pcChange2 := calculatePercentageChange(y3Input, y2Input)
     wave.boxTime0 := wave.time4 - wave.timeDelta2
     wave.boxTime1 := wave.time4 + wave.timeDelta2
     wave.boxTopPrice := (wave.price2 - wave.price1) + wave.price2               // E:  BD = AB
@@ -536,17 +558,29 @@ if barstate.islastconfirmedhistory
     wave.boxTopPrice3 := 3 * (wave.price4 - wave.price3) + (wave.boxTopPrice - wave.price4) + wave.price3
     wave.boxTopPrice4 := 4 * (wave.price4 - wave.price3) + (wave.boxTopPrice - wave.price4) + wave.price3
     wave.boxTopPrice5 := 5 * (wave.price4 - wave.price3) + (wave.boxTopPrice - wave.price4) + wave.price3
-    wave.boxPriceDBot := (wave.price5 - wave.price1) * 0.5 + wave.price1
+    wave.midADPrice := (math.abs(wave.priceD - wave.price1) * 0.5) + math.min(wave.price1, wave.priceD)                         // FIXME not really AD mid, have to find low and high of A,B,C,D
+    wave.boxPriceEBot := wave.midADPrice
     float proxy = wave.boxTopPrice                                              // FIXME please do way better than this
-    if (wave.price5 > wave.price4)
+    if (wave.priceD > wave.price4)
         proxy := wave.price4
-    if (wave.price5 > wave.boxTopPrice)
+    if (wave.priceD > wave.boxTopPrice)
         proxy := wave.boxTopPrice
-    if (wave.price5 > (wave.boxTopPrice2 - (wave.boxTopPrice - wave.price4)))
+    if (wave.priceD > (wave.boxTopPrice2 - (wave.boxTopPrice - wave.price4)))
         proxy := (wave.boxTopPrice2 - (wave.boxTopPrice - wave.price4))
-    wave.boxPriceDTop := wave.boxPriceDBot + (wave.price5 - proxy)             // Bot + (D - 2N or D - E or D - N)
-    wave.boxTime2 := (wave.time5 - wave.time3) + wave.time5
-    wave.boxTime3 := (wave.time5 - wave.time1) + wave.time5
+    wave.boxPriceETop := wave.boxPriceEBot + (wave.priceD - proxy)             // Bot + (D - 2N or D - E or D - N)
+    if wave.priceD < wave.midADPrice
+        if (wave.priceD < wave.price4)
+            proxy := wave.price4
+        if (wave.priceD < wave.boxTopPrice)
+            proxy := wave.boxTopPrice
+        if (wave.priceD < (wave.boxTopPrice2 - (wave.boxTopPrice - wave.price4)))
+            proxy := (wave.boxTopPrice2 - (wave.boxTopPrice - wave.price4))
+        wave.boxPriceETop := wave.boxPriceEBot - math.abs(wave.priceD - proxy)             // Bot + (D - 2N or D - E or D - N)        
+        // float temp = wave.boxPriceETop
+        // wave.boxPriceETop := wave.boxPriceEBot
+        // wave.boxPriceEBot := temp
+    wave.boxTimeE0 := (wave.timeD - wave.time3) + wave.timeD
+    wave.boxTimeE1 := (wave.timeD - wave.time1) + wave.timeD
     wave.barWidthInPixels := math.abs(bar_index - bar_index[1])
 
     drawIndicator(wave)
@@ -558,10 +592,10 @@ if barstate.islast
 
 // Ichimoku stuff
 plot(ichi ? conversionLine : na, color=#4385ff, title="Tekan Conversion Line")                                        // TENKAN SEN
-plot(ichi ? baseLine : na, color=#f83737, title="Kijun Base Line")                                                    // KIJUN SEN
-plot(ichi ? close : na, offset = -displacement + 1, color=#43A047, title="Lagging Span")
-p1 = plot(ichi ? leadLine1 : na, offset = displacement - 1, color=#A5D6A7, title="Leading Span A")
-p2 = plot(ichi ? leadLine2 : na, offset = displacement - 1, color=#EF9A9A, title="Leading Span B")
+plot(ichi ? baseLine : na, color=#f83737, title="Kijun Reference Line")                                                    // KIJUN SEN
+plot(ichi ? close : na, offset = -displacement + 1, color=#43A047, title="Lagging Chikou Span")
+p1 = plot(ichi ? leadLine1 : na, offset = displacement - 1, color=#A5D6A7, title="Leading Senkou Span A")
+p2 = plot(ichi ? leadLine2 : na, offset = displacement - 1, color=#EF9A9A, title="Leading Senkou Span B")
 //plot(ichi ? (leadLine1 > leadLine2 ? leadLine1 : leadLine2) : na, offset = displacement - 1, title = "Kumo Cloud Upper Line", color = #7eff83, display = display.none)
 //plot(ichi ? (leadLine1 < leadLine2 ? leadLine1 : leadLine2) : na, offset = displacement - 1, title = "Kumo Cloud Lower Line", color = #ff6464, display = display.none)
 fill(p1, p2, color = leadLine1 > leadLine2 ? color.rgb(67, 160, 71, 90) : color.rgb(244, 67, 54, 90))
@@ -585,7 +619,7 @@ if crss and barstate.islastconfirmedhistory
 
     // Kihon Suchi Cycles
     if kisu
-        int[] cycles = array.from(9,17,26,33,42,51,65,76)
+        int[] cycles = array.from(9,17,26,33,42,51,65,76,83,97,101,151,226)
         for i = array.size(cycles) - 1 to 0
             cycle = array.get(cycles, i) + lastCrossBar
             line.new(cycle, math.min(y1Input, y2Input, y3Input), cycle, math.max(y1Input, y2Input, y3Input), xloc.bar_index, extend.none, color.yellow, line.style_dotted, 1)

--- a/KOndulat.pine
+++ b/KOndulat.pine
@@ -189,6 +189,8 @@ var labelFibo100 = label.new(x=na, y=na, text=" 100 %", color=color.rgb(120, 123
 var labelFibo123 = label.new(x=na, y=na, text=" 123 %", color=color.rgb(120, 123, 134, 100), textcolor = labelFiboTextColorGoal, style=label.style_label_left, xloc=xloc.bar_time)
 var labelFibo138 = label.new(x=na, y=na, text=" 138 %", color=color.rgb(120, 123, 134, 100), textcolor = labelFiboTextColorGoal, style=label.style_label_left, xloc=xloc.bar_time)
 var labelFibo161 = label.new(x=na, y=na, text=" 161 %", color=color.rgb(120, 123, 134, 100), textcolor = labelFiboTextColorGold, style=label.style_label_left, xloc=xloc.bar_time)
+var labelFibo178 = label.new(x=na, y=na, text=" 178 %", color=color.rgb(120, 123, 134, 100), textcolor = labelFiboTextColorGold, style=label.style_label_left, xloc=xloc.bar_time)
+var labelFibo200 = label.new(x=na, y=na, text=" 200 %", color=color.rgb(120, 123, 134, 100), textcolor = labelFiboTextColorGold, style=label.style_label_left, xloc=xloc.bar_time)
 
 var labelFiboN0 = label.new(x=na, y=na, text="-0 %", color=color.rgb(120, 123, 134, 100), textcolor = labelFiboTextColorNeg, style=label.style_label_right, xloc=xloc.bar_time)
 var labelFiboN23 = label.new(x=na, y=na, text="-23.6 %", color=color.rgb(120, 123, 134, 100), textcolor = labelFiboTextColorNeg, style=label.style_label_right, xloc=xloc.bar_time)
@@ -204,6 +206,7 @@ drawIndicator(Wave t) =>
     // Wave lines, Box and Arrows
     line.new(t.time1, t.price1, t.time2, t.price2, xloc = xloc.bar_time, color = t.lineColor, width=3, style=line.style_dotted)                                                                                                     // dotted impulse
     line.new(t.time2, t.price2, t.time3, t.price3, xloc = xloc.bar_time, color = t.lineColor, width=3, style=line.style_dotted)                                                                                                     // dotted correction
+    line.new(t.time3, t.price3, t.time5, t.price5, xloc = xloc.bar_time, color = t.lineColor, width=3, style=line.style_dotted)                                                                                                     // dotted D wave
     line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.price3 + t.priceDelta1, xloc = xloc.bar_time, color = t.arrowColor1, width=1, style=line.style_arrow_right)                                                               // orange arrow N (prime)
     line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxTopPrice, xloc = xloc.bar_time, color = t.arrowColor2, width=1, style=line.style_arrow_right)                                                                          // blue arrow E (highest)
     line.new(t.boxTime0, t.price4, t.boxTime1, t.price4, xloc = xloc.bar_time, color = t.arrowColor1, width=1, style=line.style_dotted)                                                                                             // level N
@@ -428,6 +431,14 @@ drawIndicator(Wave t) =>
         line.new(offsetXFiboM, fibo161, offsetXFiboR, fibo161, xloc = xloc.bar_time, color = labelFiboTextColorGold, width=1, style=line.style_solid)    // 161%
         labelFibo161.set_x(offsetXFiboR), labelFibo161.set_y(fibo161)
 
+        var fibo178 = 178.4 * ((t.price4 - t.price3) / 100) + t.price3
+        line.new(offsetXFiboM, fibo178, offsetXFiboR, fibo178, xloc = xloc.bar_time, color = labelFiboTextColorGold, width=1, style=line.style_solid)    // 178%
+        labelFibo178.set_x(offsetXFiboR), labelFibo178.set_y(fibo178)
+
+        var fibo200 = 200.0 * ((t.price4 - t.price3) / 100) + t.price3
+        line.new(offsetXFiboM, fibo200, offsetXFiboR, fibo200, xloc = xloc.bar_time, color = labelFiboTextColorGold, width=1, style=line.style_solid)    // 200%
+        labelFibo200.set_x(offsetXFiboR), labelFibo200.set_y(fibo200)        
+
         line.new(offsetXFiboL, t.price2, offsetXFiboM, t.price2, xloc = xloc.bar_time, color = labelFiboTextColorNeg, width=1, style=line.style_solid)    // 0% at B
         labelFiboN0.set_x(offsetXFiboL), labelFiboN0.set_y(t.price2)    
 
@@ -454,8 +465,8 @@ drawIndicator(Wave t) =>
         line.new(offsetXFiboL, t.price1, offsetXFiboM, t.price1, xloc = xloc.bar_time, color = labelFiboTextColorNegCrash, width=1, style=line.style_solid)    // -100%
         labelFiboN100.set_x(offsetXFiboL), labelFiboN100.set_y(t.price1)
 
-        var topAxis = math.max(t.price1, t.price2, fibo161, t.price3)
-        var botAxis = math.min(t.price1, t.price2, fibo161, t.price3)
+        var topAxis = math.max(t.price1, t.price2, fibo200, t.price3)
+        var botAxis = math.min(t.price1, t.price2, fibo200, t.price3)
         line.new(offsetXFiboM, botAxis, offsetXFiboM, topAxis, xloc = xloc.bar_time, color = fiboAxisColor, width=1, style=line.style_solid)   // vertical scale axis
         
 formatPrice(float predi) =>
@@ -526,7 +537,14 @@ if barstate.islastconfirmedhistory
     wave.boxTopPrice4 := 4 * (wave.price4 - wave.price3) + (wave.boxTopPrice - wave.price4) + wave.price3
     wave.boxTopPrice5 := 5 * (wave.price4 - wave.price3) + (wave.boxTopPrice - wave.price4) + wave.price3
     wave.boxPriceDBot := (wave.price5 - wave.price1) * 0.5 + wave.price1
-    wave.boxPriceDTop := wave.boxPriceDBot + (wave.price5 - (wave.boxTopPrice2 - (wave.boxTopPrice - wave.price4)))             // Bot + (D - 2N)
+    float proxy = wave.boxTopPrice                                              // FIXME please do way better than this
+    if (wave.price5 > wave.price4)
+        proxy := wave.price4
+    if (wave.price5 > wave.boxTopPrice)
+        proxy := wave.boxTopPrice
+    if (wave.price5 > (wave.boxTopPrice2 - (wave.boxTopPrice - wave.price4)))
+        proxy := (wave.boxTopPrice2 - (wave.boxTopPrice - wave.price4))
+    wave.boxPriceDTop := wave.boxPriceDBot + (wave.price5 - proxy)             // Bot + (D - 2N or D - E or D - N)
     wave.boxTime2 := (wave.time5 - wave.time3) + wave.time5
     wave.boxTime3 := (wave.time5 - wave.time1) + wave.time5
     wave.barWidthInPixels := math.abs(bar_index - bar_index[1])

--- a/KOndulat.pine
+++ b/KOndulat.pine
@@ -1,5 +1,5 @@
 //@version=5
-indicator("Kir Ondulatoire", shorttitle="KOndulat", overlay=true)
+indicator("Kir Ondulatoire", shorttitle="KOndulat", overlay=true, max_labels_count = 100)
 
     // version 0.9.4
 
@@ -36,9 +36,10 @@ mult = input.bool(defval=false, title="Multiples of E/N waves", inline="option2"
 ebox = input.bool(defval=false, title="E-Box", inline="option3", group="Wave options", tooltip="Need the point D to be placed after time C")
 ecol = input.color(defval=color.aqua, title=" ", inline="option3", group="Wave options")
 tend = input.bool(defval=false, title="Straight Linear Projection", inline="option4", group="Wave options", tooltip="As long as the TARGET TIME is not reached, a purple arrow will point to the target. A purple label will give the estimated target price. It's a silly feature.")
-labp = input.bool(defval=false, title="Prices in labels", inline="option5", group="Wave options")
+labp = input.bool(defval=false, title="Price in labels", inline="option5", group="Wave options")
 tren = input.bool(defval=false, title="Wave Trend Lines", inline="option6", group="Wave options", tooltip = "Only visibles if D label is also visible. Help to visually confirm if ABCD is an N/Y/P wave.")
 tcol = input.color(defval=color.green, title=" ", inline="option6", group="Wave options")
+twid = input.int(defval=2, title="Width", inline="option6", group="Wave options")
 
 ichi = input.bool(defval=false, title="Ichimoku Kinko Hyo", inline="option1", group="Ichimoku options")
 crss = input.bool(defval=false, title="Tenkan Crossover/under markers", inline="option2", group="Ichimoku options")
@@ -160,7 +161,8 @@ _barForTime(_t) =>
         _bar := bar_index
     _bar
 
-nb_seconds = timeframe.in_seconds(timeframe.period)
+int nb_seconds = timeframe.in_seconds(timeframe.period)
+int candleTime = nb_seconds * 1000
 
 var labelRetracementBC = label.new(x=na, y=na, text="Retracement BC: na", color=color.rgb(70, 3, 81, 45), textcolor=color.rgb(255, 255, 255), style=label.style_label_up, xloc=xloc.bar_time)
 
@@ -255,8 +257,9 @@ drawIndicator(Wave t) =>
         line.new(t.boxTime0, t.boxSmPrice, t.boxTime1, t.boxSmPrice, xloc = xloc.bar_time, color = t.arrowColorVSm, width=1, style=line.style_dotted)                                                                                    // level Sm
 
     if ac26
-        int time1plus26 = t.time1 + (26 * nb_seconds * 1000)
-        int time3plus26 = t.time3 + (26 * nb_seconds * 1000)
+        int candleTime25x = 25 * candleTime
+        int time1plus26 = t.time1 + candleTime25x
+        int time3plus26 = t.time3 + candleTime25x
         float highest = math.max(t.price1, t.price2, t.price3, t.priceD, t.boxTopPrice)
         float lowest = math.min(t.price1, t.price2, t.price3, t.priceD, t.boxTopPrice)
         line.new(time1plus26, highest, time1plus26, lowest, xloc = xloc.bar_time, color = color.orange, width=1, style=line.style_dotted)                                                                                             // time A + 26 periods
@@ -280,7 +283,7 @@ drawIndicator(Wave t) =>
         line.new(t.boxTime0, t.boxTopPrice5 - (t.boxTopPrice - t.price4), t.boxTime1, t.boxTopPrice5 - (t.boxTopPrice - t.price4), xloc = xloc.bar_time, color = t.arrowColorNS, width=1, style=line.style_dotted)                       // level 5N
         line.new(t.boxTime0, t.boxTopPrice5, t.boxTime1, t.boxTopPrice5, xloc = xloc.bar_time, color = t.arrowColorEY, width=1, style=line.style_dotted)                                                                                 // level 5E
 
-    line.new(t.time3 + t.timeDelta2 - nb_seconds, t.price3, t.time3 + t.timeDelta2 - nb_seconds, t.boxTopPrice, xloc = xloc.bar_time, color = t.arrowColorVSm, width=1, style=line.style_dashed)                                         // dashed at double correction time
+    line.new(t.time3 + t.timeDelta2, t.price3, t.time3 + t.timeDelta2, t.boxTopPrice, xloc = xloc.bar_time, color = t.arrowColorVSm, width=1, style=line.style_dashed)                                                                   // dashed at double correction time
 
     box.new(t.boxTime0, t.boxTopPrice, t.boxTime1, t.price3, border_color = color.teal, border_width = 1, border_style = line.style_solid, bgcolor = na, xloc=xloc.bar_time)                                                           // target box deadline
     line.new(t.time3 + t.timeDelta1, t.boxTopPrice, t.time3 + t.timeDelta1, t.price3, xloc=xloc.bar_time, style = line.style_dashed, width = 1, color=color.teal)                                                                      // target dashed dateline
@@ -346,94 +349,94 @@ drawIndicator(Wave t) =>
         labelTargetPriceE.set_x(t.boxTime1)
         labelTargetPriceE.set_y(t.boxTopPrice)
         labelTargetPriceE.set_yloc(yloc.price)
-        labelTargetPriceE.set_text("E=" + str.format("{0, number, #.##}", t.boxTopPrice))
+        labelTargetPriceE.set_text("E=" + str.format("{0, number, #.####}", t.boxTopPrice))
 
         labelTargetPriceN.set_x(t.boxTime1)
         labelTargetPriceN.set_y(t.price4)
         labelTargetPriceN.set_yloc(yloc.price)
-        labelTargetPriceN.set_text("N=" + str.format("{0, number, #.##}", t.price4))
+        labelTargetPriceN.set_text("N=" + str.format("{0, number, #.####}", t.price4))
 
         labelTargetPriceV.set_x(t.boxTime1)
         labelTargetPriceV.set_y(t.boxVPrice)
         labelTargetPriceV.set_yloc(yloc.price)
-        labelTargetPriceV.set_text("V=" + str.format("{0, number, #.##}", t.boxVPrice))
+        labelTargetPriceV.set_text("V=" + str.format("{0, number, #.####}", t.boxVPrice))
 
     if t.pWave == false and t.sWave == false
         labelTargetPriceNt.set_x(t.boxTime1)
         labelTargetPriceNt.set_y(t.boxNtPrice)
         labelTargetPriceNt.set_yloc(yloc.price)
-        labelTargetPriceNt.set_text("NT=" + str.format("{0, number, #.##}", t.boxNtPrice))
+        labelTargetPriceNt.set_text("NT=" + str.format("{0, number, #.####}", t.boxNtPrice))
 
     if t.pWave
         labelTargetPriceP.set_x(t.boxTime1)
         labelTargetPriceP.set_y(t.boxPPrice)
         labelTargetPriceP.set_yloc(yloc.price)
-        labelTargetPriceP.set_text("P=" + str.format("{0, number, #.##}", t.boxPPrice))
+        labelTargetPriceP.set_text("P=" + str.format("{0, number, #.####}", t.boxPPrice))
 
     if t.sWave
         labelTargetPriceY.set_x(t.boxTime1)
         labelTargetPriceY.set_y(t.boxYPrice)
         labelTargetPriceY.set_yloc(yloc.price)
-        labelTargetPriceY.set_text("Y=" + str.format("{0, number, #.##}", t.boxYPrice))
+        labelTargetPriceY.set_text("Y=" + str.format("{0, number, #.####}", t.boxYPrice))
 
         labelTargetPriceS.set_x(t.boxTime1)
         labelTargetPriceS.set_y(t.boxSPrice)
         labelTargetPriceS.set_yloc(yloc.price)
-        labelTargetPriceS.set_text("S=" + str.format("{0, number, #.##}", t.boxSPrice))
+        labelTargetPriceS.set_text("S=" + str.format("{0, number, #.####}", t.boxSPrice))
 
         labelTargetPriceSm.set_x(t.boxTime1)
         labelTargetPriceSm.set_y(t.boxSmPrice)
         labelTargetPriceSm.set_yloc(yloc.price)
-        labelTargetPriceSm.set_text("Sm=" + str.format("{0, number, #.##}", t.boxSmPrice))
+        labelTargetPriceSm.set_text("Sm=" + str.format("{0, number, #.####}", t.boxSmPrice))
         
     if mult and t.sWave == false
         labelTargetPrice2E.set_x(t.boxTime1)
         labelTargetPrice2E.set_y(t.boxTopPrice2)
         labelTargetPrice2E.set_yloc(yloc.price)
-        labelTargetPrice2E.set_text("2E=" + str.format("{0, number, #.##}", t.boxTopPrice2))
+        labelTargetPrice2E.set_text("2E=" + str.format("{0, number, #.####}", t.boxTopPrice2))
 
         labelTargetPrice2N.set_x(t.boxTime1)
         labelTargetPrice2N.set_y(t.boxTopPrice2 - (t.boxTopPrice - t.price4))
         labelTargetPrice2N.set_yloc(yloc.price)
-        labelTargetPrice2N.set_text("2N=" + str.format("{0, number, #.##}", t.boxTopPrice2 - (t.boxTopPrice - t.price4)))
+        labelTargetPrice2N.set_text("2N=" + str.format("{0, number, #.####}", t.boxTopPrice2 - (t.boxTopPrice - t.price4)))
 
         labelTargetPrice3E.set_x(t.boxTime1)
         labelTargetPrice3E.set_y(t.boxTopPrice3)
         labelTargetPrice3E.set_yloc(yloc.price)
-        labelTargetPrice3E.set_text("3E=" + str.format("{0, number, #.##}", t.boxTopPrice3))
+        labelTargetPrice3E.set_text("3E=" + str.format("{0, number, #.####}", t.boxTopPrice3))
 
         labelTargetPrice3N.set_x(t.boxTime1)
         labelTargetPrice3N.set_y(t.boxTopPrice3 - (t.boxTopPrice - t.price4))
         labelTargetPrice3N.set_yloc(yloc.price)
-        labelTargetPrice3N.set_text("3N=" + str.format("{0, number, #.##}", t.boxTopPrice3 - (t.boxTopPrice - t.price4)))
+        labelTargetPrice3N.set_text("3N=" + str.format("{0, number, #.####}", t.boxTopPrice3 - (t.boxTopPrice - t.price4)))
 
         labelTargetPrice4E.set_x(t.boxTime1)
         labelTargetPrice4E.set_y(t.boxTopPrice4)
         labelTargetPrice4E.set_yloc(yloc.price)
-        labelTargetPrice4E.set_text("4E=" + str.format("{0, number, #.##}", t.boxTopPrice4))
+        labelTargetPrice4E.set_text("4E=" + str.format("{0, number, #.####}", t.boxTopPrice4))
 
         labelTargetPrice4N.set_x(t.boxTime1)
         labelTargetPrice4N.set_y(t.boxTopPrice4 - (t.boxTopPrice - t.price4))
         labelTargetPrice4N.set_yloc(yloc.price)
-        labelTargetPrice4N.set_text("4N=" + str.format("{0, number, #.##}", t.boxTopPrice4 - (t.boxTopPrice - t.price4)))
+        labelTargetPrice4N.set_text("4N=" + str.format("{0, number, #.####}", t.boxTopPrice4 - (t.boxTopPrice - t.price4)))
         
         labelTargetPrice5E.set_x(t.boxTime1)
         labelTargetPrice5E.set_y(t.boxTopPrice5)
         labelTargetPrice5E.set_yloc(yloc.price)
-        labelTargetPrice5E.set_text("5E=" + str.format("{0, number, #.##}", t.boxTopPrice5))
+        labelTargetPrice5E.set_text("5E=" + str.format("{0, number, #.####}", t.boxTopPrice5))
 
         labelTargetPrice5N.set_x(t.boxTime1)
         labelTargetPrice5N.set_y(t.boxTopPrice5 - (t.boxTopPrice - t.price4))
         labelTargetPrice5N.set_yloc(yloc.price)
-        labelTargetPrice5N.set_text("5N=" + str.format("{0, number, #.##}", t.boxTopPrice5 - (t.boxTopPrice - t.price4)))
+        labelTargetPrice5N.set_text("5N=" + str.format("{0, number, #.####}", t.boxTopPrice5 - (t.boxTopPrice - t.price4)))
 
     // Point D is only labeled if positionned after Time C
     if t.timeD > t.time3
-        label.new(t.timeD, t.priceD, "D\n" + str.format("{0, number, ###}", 1 + ((t.timeD - t.time1) / nb_seconds / 1000)) + (labp ? "\n" + str.format("{0, number, #.##}", t.priceD) : ""), xloc.bar_time, yloc.price, pointFillColor, styleABC2, pointTextColor, size.small, text.align_center)
+        label.new(t.timeD, t.priceD, "D\n" + str.format("{0, number, ###}", 1 + ((t.timeD - t.time1) / nb_seconds / 1000)) + (labp ? "\n" + str.format("{0, number, #.####}", t.priceD) : ""), xloc.bar_time, yloc.price, pointFillColor, styleABC2, pointTextColor, size.small, text.align_center)
         // Trendlines are drawable since D is visible
         if tren
-            line.new(t.time1, t.price1, t.time3, t.price3, xloc=xloc.bar_time, color=tcol, style = line.style_solid, width=1, extend = extend.both)
-            line.new(t.time2, t.price2, t.timeD, t.priceD, xloc=xloc.bar_time, color=tcol, style = line.style_solid, width=1, extend = extend.both)
+            line.new(t.time1, t.price1, t.time3, t.price3, xloc=xloc.bar_time, color=tcol, style = line.style_solid, width=twid, extend = extend.both)
+            line.new(t.time2, t.price2, t.timeD, t.priceD, xloc=xloc.bar_time, color=tcol, style = line.style_solid, width=twid, extend = extend.both)
 
     // E-Box: If Point D has been placed after Point C, we have some prediction to make
     if ebox and t.timeD > t.time3
@@ -443,11 +446,11 @@ drawIndicator(Wave t) =>
         labelTargetPriceETop.set_x(t.boxTimeE1)
         labelTargetPriceETop.set_y(t.boxPriceETop)
         labelTargetPriceETop.set_yloc(yloc.price)
-        labelTargetPriceETop.set_text(str.format("{0, number, #.##}", t.boxPriceETop))        
+        labelTargetPriceETop.set_text(str.format("{0, number, #.####}", t.boxPriceETop))        
         labelTargetPriceEBot.set_x(t.boxTimeE1)
         labelTargetPriceEBot.set_y(t.boxPriceEBot)
         labelTargetPriceEBot.set_yloc(yloc.price)
-        labelTargetPriceEBot.set_text(str.format("{0, number, #.##}", t.boxPriceEBot))
+        labelTargetPriceEBot.set_text(str.format("{0, number, #.####}", t.boxPriceEBot))
         labelBeforeTargetETime.set_x(t.boxTimeE0)
         labelBeforeTargetETime.set_y(t.boxPriceEBot)
         labelBeforeTargetETime.set_yloc(yloc.price)
@@ -461,18 +464,19 @@ drawIndicator(Wave t) =>
             labelAfterTargetETime.set_style(label.style_label_down)
 
     if ksob and kisu == false
-        int pointB = t.time2 - (nb_seconds * 1000)
-        int[] cycles = array.from(9,17,26,33,42,51,65,76,83,97,101,151,226)
+        int pointB = t.time2 - candleTime
+        int[] cycles = array.from(0,9,17,26,33,42,51,65,76,83,97,101,151,226)
         for i = array.size(cycles) - 1 to 0
             if array.get(cycles, i) <= ksmx 
-                cycle = (array.get(cycles, i) * nb_seconds * 1000) + pointB
-                line.new(cycle, math.min(y1Input, y2Input, y3Input), cycle, math.max(y1Input, y2Input, y3Input), xloc.bar_time, extend.both, color.blue, line.style_solid, 2)
+                cycle = (array.get(cycles, i) * candleTime) + pointB
+                if i > 0
+                    line.new(cycle, math.min(y1Input, y2Input, y3Input), cycle, math.max(y1Input, y2Input, y3Input), xloc.bar_time, extend.both, color.rgb(33, 149, 243, 50), line.style_dotted, 2)
                 label.new(cycle, t.price2, str.format("{0, number, ##}", array.get(cycles, i)), xloc.bar_time, yloc.price, color.rgb(27, 32, 36, 100), label.style_label_left, color.blue )
 
     if fibo
-        var offsetXFiboM = (nb_seconds * 1000 * fiboBarOffset) + t.time2
-        var offsetXFiboL = offsetXFiboM - (nb_seconds * 1000 * fiboBarWidth)
-        var offsetXFiboR = offsetXFiboM + (nb_seconds * 1000 * fiboBarWidth)
+        var offsetXFiboM = (candleTime * fiboBarOffset) + t.time2
+        var offsetXFiboL = offsetXFiboM - (candleTime * fiboBarWidth)
+        var offsetXFiboR = offsetXFiboM + (candleTime * fiboBarWidth)
         var fiboScaleColor = color.rgb(31, 205, 187)
         var fiboAxisColor = color.rgb(92, 234, 220)
         var fiboZeroColor = color.rgb(31, 205, 187, 42)
@@ -565,7 +569,7 @@ drawSLP(Wave t) =>
     if tend and t.time4 > t.currentTime
         var nBarOvershoot = 5
         var predi = t.price3 + ((t.currentPrice - t.price3)*(t.time4 - t.time3))/(t.currentTime - t.time3)
-        var timeAtOvershoot = t.time4 //t.currentTime + (nBarOvershoot * nb_seconds * 1000)
+        var timeAtOvershoot = t.time4 //t.currentTime + (nBarOvershoot * candleTime)
         var slpPrice = t.price3 + ((t.currentPrice - t.price3)*(timeAtOvershoot - t.time3))/(t.currentTime - t.time3)
 
         label.new(t.currentTime, na, "SLP=" + formatPrice(predi), xloc.bar_time, yloc.abovebar, color.rgb(132, 0, 255), label.style_label_lower_left, size=size.small, textcolor = color.rgb(255, 255, 255), textalign = text.align_center)
@@ -663,19 +667,33 @@ if barstate.islast
 
 // Ichimoku stuff
 plot(ichi ? conversionLine : na, color=#4385ff, title="Tekan Conversion Line")                                        // TENKAN SEN
-plot(ichi ? baseLine : na, color=#f83737, title="Kijun Reference Line")                                                    // KIJUN SEN
+plot(ichi ? baseLine : na, color=#f83737, title="Kijun Base Line")                                                    // KIJUN SEN
 plot(ichi ? close : na, offset = -displacement + 1, color=#43A047, title="Lagging Chikou Span")
 p1 = plot(ichi ? leadLine1 : na, offset = displacement - 1, color=#A5D6A7, title="Leading Senkou Span A")
 p2 = plot(ichi ? leadLine2 : na, offset = displacement - 1, color=#EF9A9A, title="Leading Senkou Span B")
 //plot(ichi ? (leadLine1 > leadLine2 ? leadLine1 : leadLine2) : na, offset = displacement - 1, title = "Kumo Cloud Upper Line", color = #7eff83, display = display.none)
 //plot(ichi ? (leadLine1 < leadLine2 ? leadLine1 : leadLine2) : na, offset = displacement - 1, title = "Kumo Cloud Lower Line", color = #ff6464, display = display.none)
 fill(p1, p2, color = leadLine1 > leadLine2 ? color.rgb(67, 160, 71, 90) : color.rgb(244, 67, 54, 90))
+plot((ichi and crss) ? (ta.crossover(conversionLine,baseLine) ? baseLine : na) : na,'Crossover',#2157f3,3,plot.style_circles)
+plot((ichi and crss) ? (ta.crossunder(conversionLine,baseLine) ? baseLine : na) : na,'Crossunder',#ff5d00,3,plot.style_circles)
 
 // Display of the Tenkan Crossover Gaps
 if crss and barstate.islastconfirmedhistory
 
     lastCrossover = array.get(crossoverBars, array.size(crossoverBars) - 1)
     lastCrossoverDist = array.get(crossoverDist, array.size(crossoverBars) - 1)
+
+    // Kihon Suchi Cycles
+    if kisu and ksob == false
+        int[] cycles = array.from(0,9,17,26,33,42,51,65,76,83,97,101,151,226)
+        for i = array.size(cycles) - 1 to 0
+            if array.get(cycles, i) <= ksmx 
+                cycle = array.get(cycles, i) + lastCrossBar
+                if i > 0
+                    line.new(cycle, math.min(y1Input, y2Input, y3Input), cycle, math.max(y1Input, y2Input, y3Input), xloc.bar_index, extend.both, color.yellow, line.style_dotted, 1)
+                label.new(cycle, y2Input, str.format("{0, number, ##}", array.get(cycles, i)), xloc.bar_index, yloc.price, color.rgb(27, 32, 36, 100), label.style_label_left, color.yellow )
+        line.new(lastCrossover + lastCrossoverDist, math.min(y1Input, y2Input, y3Input), lastCrossover + lastCrossoverDist, math.max(y1Input, y2Input, y3Input), xloc.bar_index, extend.both, color.rgb(255, 217, 0), line.style_dashed, 1)
+        label.new(lastCrossover + lastCrossoverDist, y2Input, str.format("{0, number, ##}", lastCrossoverDist), xloc.bar_index, yloc.price, color.rgb(128, 128, 128, 80), label.style_label_up, color.yellow )
 
     // Print the list of crossover bars and distances
     for i = array.size(crossoverBars) - 1 to 0
@@ -687,15 +705,6 @@ if crss and barstate.islastconfirmedhistory
                 label.new(v, na, "⬅ " + str.format("{0, number, ###}", d) + "\n→" + str.format("{0, number, ###}", 1 + bar_index - lastCrossover), xloc.bar_index, yloc.abovebar, color.rgb(255, 0, 0), label.style_arrowdown, color.rgb(117, 188, 255), size.normal)
             else    
                 label.new(v, na, "⬅ " + str.format("{0, number, ###}", d), xloc.bar_index, yloc.abovebar, color.rgb(255, 0, 0), label.style_arrowdown, color.rgb(117, 188, 255), size.normal)
-
-    // Kihon Suchi Cycles
-    if kisu and ksob == false
-        int[] cycles = array.from(9,17,26,33,42,51,65,76,83,97,101,151,226)
-        for i = array.size(cycles) - 1 to 0
-            if array.get(cycles, i) <= ksmx 
-                cycle = array.get(cycles, i) + lastCrossBar
-                line.new(cycle, math.min(y1Input, y2Input, y3Input), cycle, math.max(y1Input, y2Input, y3Input), xloc.bar_index, extend.none, color.yellow, line.style_dotted, 1)
-        line.new(lastCrossover + lastCrossoverDist, math.min(y1Input, y2Input, y3Input), lastCrossover + lastCrossoverDist, math.max(y1Input, y2Input, y3Input), xloc.bar_index, extend.none, color.rgb(255, 217, 0), line.style_dashed, 1)
 
 // EMA
 out = ta.ema(src, len)

--- a/KOndulat.pine
+++ b/KOndulat.pine
@@ -31,16 +31,25 @@ y3Input = input.price(PRICE_DEFAULT, "",        inline = "3", tooltip = "Pick po
 x4Input = input.time(TIME_DEFAULT,   "Point D", inline = "4", confirm = true)
 y4Input = input.price(PRICE_DEFAULT, "",        inline = "4", tooltip = "Pick point D (place before C to ignore)", confirm = true)
 
-mult = input.bool(defval=false, title="Multiples of E/N waves", inline="option1", group="Miscellaneous options")
-fibo = input.bool(defval=false, title="Fibonacci Axis", inline="option2", group="Miscellaneous options")
-tend = input.bool(defval=false, title="Straight Linear Projection", inline="option3", group="Miscellaneous options")
-kisu = input.bool(defval=false, title="Kihon Suchi series", inline="option4", group="Miscellaneous options", tooltip = "Need Tenkan crossovers to be displayed to add predictions")
-ichi = input.bool(defval=false, title="Ichimoku Kinko Hyo", inline="option5", group="Miscellaneous options")
-crss = input.bool(defval=false, title="Tenkan Crossover Markers", inline="option6", group="Miscellaneous options")
-dema = input.bool(defval=false, title="EMA", inline="options7", group="Miscellaneous options")
-labp = input.bool(defval=false, title="Prices in labels", inline="options8", group="Miscellaneous options")
-tren = input.bool(defval=false, title="Wave Trend Lines", inline="options9", group="Miscellaneous options", tooltip = "Only visibles if D label is also visible. Help to visually confirm if ABCD is an N/Y/P wave.")
-ac26 = input.bool(defval=false, title="26 periods after A/C", inline="options10", group="Miscellaneous options", tooltip = "The Kumo cloud between those two deadlines gives an active area to keep an eye on. Up to you to draw a bounding box there.")
+pret = input.float(defval=50.0, title="% Retracement for a P-Wave", inline="option1", group="Wave options", tooltip="By default, a P wave is forming if the move BC retraced more than 50% of AB. N waves are more certain between 33% and 50%. Alter this if you think the situation is blurry.")
+mult = input.bool(defval=false, title="Multiples of E/N waves", inline="option2", group="Wave options", tooltip="Won't work in case of an S-Wave")
+ebox = input.bool(defval=false, title="E-Box", inline="option3", group="Wave options", tooltip="Need the point D to be placed after time C")
+ecol = input.color(defval=color.aqua, title=" ", inline="option3", group="Wave options")
+tend = input.bool(defval=false, title="Straight Linear Projection", inline="option4", group="Wave options", tooltip="As long as the TARGET TIME is not reached, a purple arrow will point to the target. A purple label will give the estimated target price. It's a silly feature.")
+labp = input.bool(defval=false, title="Prices in labels", inline="option5", group="Wave options")
+tren = input.bool(defval=false, title="Wave Trend Lines", inline="option6", group="Wave options", tooltip = "Only visibles if D label is also visible. Help to visually confirm if ABCD is an N/Y/P wave.")
+tcol = input.color(defval=color.green, title=" ", inline="option6", group="Wave options")
+
+ichi = input.bool(defval=false, title="Ichimoku Kinko Hyo", inline="option1", group="Ichimoku options")
+crss = input.bool(defval=false, title="Tenkan Crossover/under markers", inline="option2", group="Ichimoku options")
+
+ksmx = input.int(defval=42, title="Max period", inline="option1", group="Kihon Suchi options", tooltip = "Won't draw Ichimoku times after this elapsed period")
+kisu = input.bool(defval=false, title="from last Crossover", inline="option1", group="Kihon Suchi options", tooltip = "Need Tenkan crossovers to be displayed to add predictions")
+ksob = input.bool(defval=false, title="from B", inline="option1", group="Kihon Suchi options", tooltip = "Won't work if previous option is checked")
+
+ac26 = input.bool(defval=false, title="26 periods after A/C", inline="option1", group="Miscellaneous options", tooltip = "The Kumo cloud between those two deadlines gives an active area to keep an eye on. Up to you to draw a bounding box there.")
+dema = input.bool(defval=false, title="EMA", inline="option2", group="Miscellaneous options")
+fibo = input.bool(defval=false, title="Fibonacci Axis", inline="option3", group="Miscellaneous options")
 
 int realtimeTime = 1
 float realtimePrice = 1.0
@@ -60,10 +69,10 @@ type Wave
     float price4
     float priceD
     color lineColor
-    color arrowColor1
-    color arrowColor2
-    color arrowColor3
-    color arrowColor4
+    color arrowColorNS
+    color arrowColorEY
+    color arrowColorVSm
+    color arrowColorNtP
     float priceDelta1
     float priceDelta2
     int   timeDelta1
@@ -77,18 +86,24 @@ type Wave
     float boxTopPrice3
     float boxTopPrice4
     float boxTopPrice5
+    float boxEPrice
     float boxVPrice
     float boxNtPrice
     float boxPPrice
+    float boxYPrice
+    float boxSPrice
+    float boxSmPrice
     float boxPriceETop
     float boxPriceEBot
     float currentPrice
     float midADPrice
     int   currentTime
     int   barWidthInPixels
+    bool  baNegative
     bool  nWave
     bool  pWave
-    bool  yWave
+    bool  sWave
+    float retracement
 
 // Fibonacci stuff
 fiboBarWidth = input.int(2, minval=-1000, maxval=1000, title="Fibo width in bars", group="Fibonacci Axis", tooltip = "Due to the lack of scale/zoom detection, the width of the graduations is expressed in a multiplier of bar width")
@@ -152,11 +167,16 @@ var labelRetracementBC = label.new(x=na, y=na, text="Retracement BC: na", color=
 var labelTargetTime = label.new(x=na, y=na, text="Test", color=color.rgb(0, 137, 123, 45), textcolor=color.rgb(255, 221, 117), style=label.style_label_up, xloc=xloc.bar_time, size=size.small)
 var labelBeforeTargetTime = label.new(x=na, y=na, text="Test", color=color.rgb(0, 137, 123, 48), textcolor=color.rgb(255, 255, 255, 34), style=label.style_label_down, xloc=xloc.bar_time, size=size.small)
 var labelAfterTargetTime = label.new(x=na, y=na, text="Test", color=color.rgb(0, 137, 123, 48), textcolor=color.rgb(255, 255, 255, 34), style=label.style_label_down, xloc=xloc.bar_time, size=size.small)
+
 var labelTargetPriceE = label.new(x=na, y=na, text="E= na", color=color.rgb(120, 123, 134, 90), textcolor=color.blue, style=label.style_label_left, xloc=xloc.bar_time)
 var labelTargetPriceN = label.new(x=na, y=na, text="N= na", color=color.rgb(120, 123, 134, 90), textcolor=color.orange, style=label.style_label_left, xloc=xloc.bar_time)
 var labelTargetPriceV = label.new(x=na, y=na, text="V= na", color=color.rgb(120, 123, 134, 90), textcolor=color.rgb(255, 82, 102), style=label.style_label_left, xloc=xloc.bar_time)
 var labelTargetPriceNt = label.new(x=na, y=na, text="NT= na", color=color.rgb(120, 123, 134, 90), textcolor=color.green, style=label.style_label_left, xloc=xloc.bar_time)
 var labelTargetPriceP = label.new(x=na, y=na, text="P= na", color=color.rgb(120, 123, 134, 90), textcolor=color.lime, style=label.style_label_left, xloc=xloc.bar_time)
+
+var labelTargetPriceY = label.new(x=na, y=na, text="Y= na", color=color.rgb(120, 123, 134, 90), textcolor=color.blue, style=label.style_label_left, xloc=xloc.bar_time)
+var labelTargetPriceS = label.new(x=na, y=na, text="S= na", color=color.rgb(120, 123, 134, 90), textcolor=color.orange, style=label.style_label_left, xloc=xloc.bar_time)
+var labelTargetPriceSm = label.new(x=na, y=na, text="Sm= na", color=color.rgb(120, 123, 134, 90), textcolor=color.rgb(255, 82, 102), style=label.style_label_left, xloc=xloc.bar_time)
 
 var labelTargetPrice2E = label.new(x=na, y=na, text="2E: na", color=color.rgb(120, 123, 134, 90), textcolor=color.blue, style=label.style_label_left, xloc=xloc.bar_time)
 var labelTargetPrice2N = label.new(x=na, y=na, text="2N: na", color=color.rgb(120, 123, 134, 90), textcolor=color.orange, style=label.style_label_left, xloc=xloc.bar_time)
@@ -167,8 +187,8 @@ var labelTargetPrice4N = label.new(x=na, y=na, text="4N: na", color=color.rgb(12
 var labelTargetPrice5E = label.new(x=na, y=na, text="4E: na", color=color.rgb(120, 123, 134, 90), textcolor=color.blue, style=label.style_label_left, xloc=xloc.bar_time)
 var labelTargetPrice5N = label.new(x=na, y=na, text="4N: na", color=color.rgb(120, 123, 134, 90), textcolor=color.orange, style=label.style_label_left, xloc=xloc.bar_time)
 
-var labelTargetPriceETop = label.new(x=na, y=na, text="Emax", color=color.rgb(120, 123, 134, 90), textcolor=color.aqua, style=label.style_label_left, xloc=xloc.bar_time)
-var labelTargetPriceEBot = label.new(x=na, y=na, text="Emin", color=color.rgb(120, 123, 134, 90), textcolor=color.aqua, style=label.style_label_left, xloc=xloc.bar_time)
+var labelTargetPriceETop = label.new(x=na, y=na, text="Emax", color=color.rgb(120, 123, 134, 90), textcolor=ecol, style=label.style_label_left, xloc=xloc.bar_time)
+var labelTargetPriceEBot = label.new(x=na, y=na, text="Emin", color=color.rgb(120, 123, 134, 90), textcolor=ecol, style=label.style_label_left, xloc=xloc.bar_time)
 var labelBeforeTargetETime = label.new(x=na, y=na, text="Test", color=color.rgb(0, 137, 123, 48), textcolor=color.rgb(255, 255, 255, 34), style=label.style_label_up, xloc=xloc.bar_time, size=size.small)
 var labelAfterTargetETime = label.new(x=na, y=na, text="Test", color=color.rgb(0, 137, 123, 48), textcolor=color.rgb(255, 255, 255, 34), style=label.style_label_up, xloc=xloc.bar_time, size=size.small)
 
@@ -202,19 +222,38 @@ var labelFiboN100 = label.new(x=na, y=na, text=" -100 %", color=color.rgb(120, 1
 drawIndicator(Wave t) =>
 
     // Wave lines, Box and Arrows
-    line.new(t.time1, t.price1, t.time2, t.price2, xloc = xloc.bar_time, color = t.lineColor, width=3, style=line.style_dotted)                                                                                                         // dotted impulse
-    line.new(t.time2, t.price2, t.time3, t.price3, xloc = xloc.bar_time, color = t.lineColor, width=3, style=line.style_dotted)                                                                                                         // dotted correction
-    line.new(t.time3, t.price3, t.timeD, t.priceD, xloc = xloc.bar_time, color = t.lineColor, width=3, style=line.style_dotted)                                                                                                         // dotted D wave
-    line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.price3 + t.priceDelta1, xloc = xloc.bar_time, color = t.arrowColor1, width=1, style=line.style_arrow_right)                                                                   // orange arrow N (prime)        C+(B-A)
-    line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxTopPrice, xloc = xloc.bar_time, color = t.arrowColor2, width=1, style=line.style_arrow_right)                                                                              // blue arrow E (highest/lowest) B+(B-A)
-    line.new(t.boxTime0, t.price4, t.boxTime1, t.price4, xloc = xloc.bar_time, color = t.arrowColor1, width=1, style=line.style_dotted)                                                                                                 // level N
-    line.new(t.boxTime0, t.boxTopPrice, t.boxTime1, t.boxTopPrice, xloc = xloc.bar_time, color = t.arrowColor2, width=1, style=line.style_dotted)                                                                                       // level E
-    line.new(t.boxTime0, t.boxVPrice, t.boxTime1, t.boxVPrice, xloc = xloc.bar_time, color = t.arrowColor3, width=1, style=line.style_dotted)                                                                                           // level V
-    if t.pWave == false
-        line.new(t.boxTime0, t.boxNtPrice, t.boxTime1, t.boxNtPrice, xloc = xloc.bar_time, color = t.arrowColor4, width=1, style=line.style_dotted)                                                                                     // level Nt
-    if t.pWave
-        line.new(t.boxTime0, t.boxPPrice, t.boxTime1, t.boxPPrice, xloc = xloc.bar_time, color = t.arrowColor4, width=1, style=line.style_dotted)                                                                                       // level P
-    
+    line.new(t.time1, t.price1, t.time2, t.price2, xloc = xloc.bar_time, color = t.lineColor, width=3, style=line.style_dotted)                                                                                                          // dotted impulse
+    line.new(t.time2, t.price2, t.time3, t.price3, xloc = xloc.bar_time, color = t.lineColor, width=3, style=line.style_dotted)                                                                                                          // dotted correction
+    line.new(t.time3, t.price3, t.timeD, t.priceD, xloc = xloc.bar_time, color = t.lineColor, width=3, style=line.style_dotted)                                                                                                          // dotted D wave
+
+    if t.nWave or t.pWave
+        // arrows
+        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.price3 + t.priceDelta1, xloc = xloc.bar_time, color = t.arrowColorNS, width=1, style=line.style_arrow_right)                                                               // orange arrow N (prime)        C+(B-A)
+        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxTopPrice, xloc = xloc.bar_time, color = t.arrowColorEY, width=1, style=line.style_arrow_right)                                                                          // blue arrow E (highest/lowest) B+(B-A)
+        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxVPrice, xloc = xloc.bar_time, color = t.arrowColorVSm, width=1, style=line.style_arrow_right)                                                                           // red arrow V      B+(B-C)
+        if t.pWave == false
+            line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxNtPrice, xloc = xloc.bar_time, color = t.arrowColorNtP, width=1, style=line.style_arrow_right)                                                                      // green arrow Nt   C+(C-A)
+        if t.pWave
+            line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxPPrice, xloc = xloc.bar_time, color = t.arrowColorNtP, width=1, style=line.style_arrow_right)                                                                       // green arrow P
+        // levels
+        line.new(t.boxTime0, t.price4, t.boxTime1, t.price4, xloc = xloc.bar_time, color = t.arrowColorNS, width=1, style=line.style_dotted)                                                                                             // level N
+        line.new(t.boxTime0, t.boxTopPrice, t.boxTime1, t.boxTopPrice, xloc = xloc.bar_time, color = t.arrowColorEY, width=1, style=line.style_dotted)                                                                                   // level E
+        line.new(t.boxTime0, t.boxVPrice, t.boxTime1, t.boxVPrice, xloc = xloc.bar_time, color = t.arrowColorVSm, width=1, style=line.style_dotted)                                                                                      // level V
+        if t.pWave == false
+            line.new(t.boxTime0, t.boxNtPrice, t.boxTime1, t.boxNtPrice, xloc = xloc.bar_time, color = t.arrowColorNtP, width=1, style=line.style_dotted)                                                                                // level Nt
+        if t.pWave
+            line.new(t.boxTime0, t.boxPPrice, t.boxTime1, t.boxPPrice, xloc = xloc.bar_time, color = t.arrowColorNtP, width=1, style=line.style_dotted)                                                                                  // level P (prime)
+
+    if t.sWave
+        // arrows
+        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxSPrice, xloc = xloc.bar_time, color = t.arrowColorNS, width=1, style=line.style_arrow_right)                                                                            // orange arrow S (prime)
+        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxYPrice, xloc = xloc.bar_time, color = t.arrowColorEY, width=1, style=line.style_arrow_right)                                                                            // blue arrow Y (highest/lowest)
+        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxSmPrice, xloc = xloc.bar_time, color = t.arrowColorVSm, width=1, style=line.style_arrow_right)                                                                          // red arrow Sm (median)
+        // levels
+        line.new(t.boxTime0, t.boxSPrice, t.boxTime1, t.boxSPrice, xloc = xloc.bar_time, color = t.arrowColorNS, width=1, style=line.style_dotted)                                                                                       // level S
+        line.new(t.boxTime0, t.boxYPrice, t.boxTime1, t.boxYPrice, xloc = xloc.bar_time, color = t.arrowColorEY, width=1, style=line.style_dotted)                                                                                       // level Y
+        line.new(t.boxTime0, t.boxSmPrice, t.boxTime1, t.boxSmPrice, xloc = xloc.bar_time, color = t.arrowColorVSm, width=1, style=line.style_dotted)                                                                                    // level Sm
+
     if ac26
         int time1plus26 = t.time1 + (26 * nb_seconds * 1000)
         int time3plus26 = t.time3 + (26 * nb_seconds * 1000)
@@ -223,33 +262,28 @@ drawIndicator(Wave t) =>
         line.new(time1plus26, highest, time1plus26, lowest, xloc = xloc.bar_time, color = color.orange, width=1, style=line.style_dotted)                                                                                             // time A + 26 periods
         line.new(time3plus26, highest, time3plus26, lowest, xloc = xloc.bar_time, color = color.orange, width=1, style=line.style_dotted)                                                                                             // time C + 26 periods
 
-    if mult
-        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxTopPrice2, xloc = xloc.bar_time, color = t.arrowColor2, width=1, style=line.style_arrow_right)                                                                         // blue arrow 2E (highest)
-        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxTopPrice2 - (t.boxTopPrice - t.price4), xloc = xloc.bar_time, color = t.arrowColor1, width=1, style=line.style_arrow_right)                                            // orange arrow 2N (prime)
-        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxTopPrice3, xloc = xloc.bar_time, color = t.arrowColor2, width=1, style=line.style_arrow_right)                                                                         // blue arrow 3E (highest)
-        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxTopPrice3 - (t.boxTopPrice - t.price4), xloc = xloc.bar_time, color = t.arrowColor1, width=1, style=line.style_arrow_right)                                            // orange arrow 3N (prime)
-        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxTopPrice4, xloc = xloc.bar_time, color = t.arrowColor2, width=1, style=line.style_arrow_right)                                                                         // blue arrow 4E (highest)
-        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxTopPrice4 - (t.boxTopPrice - t.price4), xloc = xloc.bar_time, color = t.arrowColor1, width=1, style=line.style_arrow_right)                                            // orange arrow 4N (prime)
-        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxTopPrice5, xloc = xloc.bar_time, color = t.arrowColor2, width=1, style=line.style_arrow_right)                                                                         // blue arrow 5E (highest)
-        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxTopPrice5 - (t.boxTopPrice - t.price4), xloc = xloc.bar_time, color = t.arrowColor1, width=1, style=line.style_arrow_right)                                            // orange arrow 5N (prime)
-        line.new(t.boxTime0, t.boxTopPrice2 - (t.boxTopPrice - t.price4), t.boxTime1, t.boxTopPrice2 - (t.boxTopPrice - t.price4), xloc = xloc.bar_time, color = t.arrowColor1, width=1, style=line.style_dotted)                       // level 2N
-        line.new(t.boxTime0, t.boxTopPrice2, t.boxTime1, t.boxTopPrice2, xloc = xloc.bar_time, color = t.arrowColor2, width=1, style=line.style_dotted)                                                                                 // level 2E
-        line.new(t.boxTime0, t.boxTopPrice3 - (t.boxTopPrice - t.price4), t.boxTime1, t.boxTopPrice3 - (t.boxTopPrice - t.price4), xloc = xloc.bar_time, color = t.arrowColor1, width=1, style=line.style_dotted)                       // level 3N
-        line.new(t.boxTime0, t.boxTopPrice3, t.boxTime1, t.boxTopPrice3, xloc = xloc.bar_time, color = t.arrowColor2, width=1, style=line.style_dotted)                                                                                 // level 3E
-        line.new(t.boxTime0, t.boxTopPrice4 - (t.boxTopPrice - t.price4), t.boxTime1, t.boxTopPrice4 - (t.boxTopPrice - t.price4), xloc = xloc.bar_time, color = t.arrowColor1, width=1, style=line.style_dotted)                       // level 4N
-        line.new(t.boxTime0, t.boxTopPrice4, t.boxTime1, t.boxTopPrice4, xloc = xloc.bar_time, color = t.arrowColor2, width=1, style=line.style_dotted)                                                                                 // level 4E
-        line.new(t.boxTime0, t.boxTopPrice5 - (t.boxTopPrice - t.price4), t.boxTime1, t.boxTopPrice5 - (t.boxTopPrice - t.price4), xloc = xloc.bar_time, color = t.arrowColor1, width=1, style=line.style_dotted)                       // level 5N
-        line.new(t.boxTime0, t.boxTopPrice5, t.boxTime1, t.boxTopPrice5, xloc = xloc.bar_time, color = t.arrowColor2, width=1, style=line.style_dotted)                                                                                 // level 5E
+    if mult and t.sWave == false
+        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxTopPrice2, xloc = xloc.bar_time, color = t.arrowColorEY, width=1, style=line.style_arrow_right)                                                                         // blue arrow 2E (highest)
+        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxTopPrice2 - (t.boxTopPrice - t.price4), xloc = xloc.bar_time, color = t.arrowColorNS, width=1, style=line.style_arrow_right)                                            // orange arrow 2N (prime)
+        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxTopPrice3, xloc = xloc.bar_time, color = t.arrowColorEY, width=1, style=line.style_arrow_right)                                                                         // blue arrow 3E (highest)
+        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxTopPrice3 - (t.boxTopPrice - t.price4), xloc = xloc.bar_time, color = t.arrowColorNS, width=1, style=line.style_arrow_right)                                            // orange arrow 3N (prime)
+        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxTopPrice4, xloc = xloc.bar_time, color = t.arrowColorEY, width=1, style=line.style_arrow_right)                                                                         // blue arrow 4E (highest)
+        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxTopPrice4 - (t.boxTopPrice - t.price4), xloc = xloc.bar_time, color = t.arrowColorNS, width=1, style=line.style_arrow_right)                                            // orange arrow 4N (prime)
+        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxTopPrice5, xloc = xloc.bar_time, color = t.arrowColorEY, width=1, style=line.style_arrow_right)                                                                         // blue arrow 5E (highest)
+        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxTopPrice5 - (t.boxTopPrice - t.price4), xloc = xloc.bar_time, color = t.arrowColorNS, width=1, style=line.style_arrow_right)                                            // orange arrow 5N (prime)
+        line.new(t.boxTime0, t.boxTopPrice2 - (t.boxTopPrice - t.price4), t.boxTime1, t.boxTopPrice2 - (t.boxTopPrice - t.price4), xloc = xloc.bar_time, color = t.arrowColorNS, width=1, style=line.style_dotted)                       // level 2N
+        line.new(t.boxTime0, t.boxTopPrice2, t.boxTime1, t.boxTopPrice2, xloc = xloc.bar_time, color = t.arrowColorEY, width=1, style=line.style_dotted)                                                                                 // level 2E
+        line.new(t.boxTime0, t.boxTopPrice3 - (t.boxTopPrice - t.price4), t.boxTime1, t.boxTopPrice3 - (t.boxTopPrice - t.price4), xloc = xloc.bar_time, color = t.arrowColorNS, width=1, style=line.style_dotted)                       // level 3N
+        line.new(t.boxTime0, t.boxTopPrice3, t.boxTime1, t.boxTopPrice3, xloc = xloc.bar_time, color = t.arrowColorEY, width=1, style=line.style_dotted)                                                                                 // level 3E
+        line.new(t.boxTime0, t.boxTopPrice4 - (t.boxTopPrice - t.price4), t.boxTime1, t.boxTopPrice4 - (t.boxTopPrice - t.price4), xloc = xloc.bar_time, color = t.arrowColorNS, width=1, style=line.style_dotted)                       // level 4N
+        line.new(t.boxTime0, t.boxTopPrice4, t.boxTime1, t.boxTopPrice4, xloc = xloc.bar_time, color = t.arrowColorEY, width=1, style=line.style_dotted)                                                                                 // level 4E
+        line.new(t.boxTime0, t.boxTopPrice5 - (t.boxTopPrice - t.price4), t.boxTime1, t.boxTopPrice5 - (t.boxTopPrice - t.price4), xloc = xloc.bar_time, color = t.arrowColorNS, width=1, style=line.style_dotted)                       // level 5N
+        line.new(t.boxTime0, t.boxTopPrice5, t.boxTime1, t.boxTopPrice5, xloc = xloc.bar_time, color = t.arrowColorEY, width=1, style=line.style_dotted)                                                                                 // level 5E
 
-    line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxVPrice, xloc = xloc.bar_time, color = t.arrowColor3, width=1, style=line.style_arrow_right)                                                                                // red arrow V      B+(B-C)
-    if t.pWave == false
-        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxNtPrice, xloc = xloc.bar_time, color = t.arrowColor4, width=1, style=line.style_arrow_right)                                                                           // green arrow Nt   C+(C-A)
-    if t.pWave
-        line.new(t.time3, t.price3, t.time3 + t.timeDelta1, t.boxPPrice, xloc = xloc.bar_time, color = t.arrowColor4, width=1, style=line.style_arrow_right)                                                                            // lime arrow P
-    line.new(t.time3 + t.timeDelta2 - nb_seconds, t.price3, t.time3 + t.timeDelta2 - nb_seconds, t.boxTopPrice, xloc = xloc.bar_time, color = t.arrowColor3, width=1, style=line.style_dashed)                                          // dashed at double correction time
+    line.new(t.time3 + t.timeDelta2 - nb_seconds, t.price3, t.time3 + t.timeDelta2 - nb_seconds, t.boxTopPrice, xloc = xloc.bar_time, color = t.arrowColorVSm, width=1, style=line.style_dashed)                                         // dashed at double correction time
 
-    box.new(t.boxTime0, t.boxTopPrice, t.boxTime1, t.price3, border_color = color.teal, border_width = 1, border_style = line.style_solid, bgcolor = na, xloc=xloc.bar_time)                                                          // target box deadline
-    line.new(t.time3 + t.timeDelta1, t.boxTopPrice, t.time3 + t.timeDelta1, t.price3, xloc=xloc.bar_time, style = line.style_dashed, width = 1, color=color.teal)                                                                     // target dateline
+    box.new(t.boxTime0, t.boxTopPrice, t.boxTime1, t.price3, border_color = color.teal, border_width = 1, border_style = line.style_solid, bgcolor = na, xloc=xloc.bar_time)                                                           // target box deadline
+    line.new(t.time3 + t.timeDelta1, t.boxTopPrice, t.time3 + t.timeDelta1, t.price3, xloc=xloc.bar_time, style = line.style_dashed, width = 1, color=color.teal)                                                                      // target dashed dateline
 
     // toggle the direction of things considering the relation between time A and time B
     var styleABC = label.style_label_up
@@ -278,18 +312,17 @@ drawIndicator(Wave t) =>
     int labelTextWidth = str.length(labelTargetPriceNt.get_text()) * 6 / 10
     //log.info(str.format("{0, number, ###.###}", labelTextWidth))
 
-    // Retracement of C over B
-    retracementBC = 100 * math.abs(t.price3 - t.price2) / math.abs(t.price2 - t.price1)
+    // Retracement of C over BA
     labelRetracementBC.set_style(styleRetrac)
     labelRetracementBC.set_x(math.floor(t.time2 + (t.time3 - t.time2)))
     labelRetracementBC.set_y(t.price2 - (1.8 * math.abs(t.price2 - t.price3)))
-    if t.price2 < t.price1
+    if t.baNegative
         labelRetracementBC.set_y(t.price2 + (1.8 * math.abs(t.price3 - t.price2)))
     labelRetracementBC.set_yloc(yloc.price)
-    labelRetracementBC.set_text("retracement BC: " + str.format("{0, number, #.##}", retracementBC) + "%")
+    labelRetracementBC.set_text("retracement BC: " + str.format("{0, number, #.##}", t.retracement) + "%")
 
     // Box date labels
-    if (t.price1 > t.price2)
+    if t.baNegative
         labelTargetTime.set_style(label.style_label_down)
         labelBeforeTargetTime.set_style(label.style_label_up), labelAfterTargetTime.set_style(label.style_label_up)
 
@@ -309,22 +342,23 @@ drawIndicator(Wave t) =>
     labelAfterTargetTime.set_text(str.format_time(t.boxTime1, 'dd-MMM-yyyy\nHH:mm:ss', "UTC+2"))
 
     // Arrow Labels
-    labelTargetPriceE.set_x(t.boxTime1)
-    labelTargetPriceE.set_y(t.boxTopPrice)
-    labelTargetPriceE.set_yloc(yloc.price)
-    labelTargetPriceE.set_text("E=" + str.format("{0, number, #.##}", t.boxTopPrice))
+    if t.sWave == false
+        labelTargetPriceE.set_x(t.boxTime1)
+        labelTargetPriceE.set_y(t.boxTopPrice)
+        labelTargetPriceE.set_yloc(yloc.price)
+        labelTargetPriceE.set_text("E=" + str.format("{0, number, #.##}", t.boxTopPrice))
 
-    labelTargetPriceN.set_x(t.boxTime1)
-    labelTargetPriceN.set_y(t.price4)
-    labelTargetPriceN.set_yloc(yloc.price)
-    labelTargetPriceN.set_text("N=" + str.format("{0, number, #.##}", t.price4))
+        labelTargetPriceN.set_x(t.boxTime1)
+        labelTargetPriceN.set_y(t.price4)
+        labelTargetPriceN.set_yloc(yloc.price)
+        labelTargetPriceN.set_text("N=" + str.format("{0, number, #.##}", t.price4))
 
-    labelTargetPriceV.set_x(t.boxTime1)
-    labelTargetPriceV.set_y(t.boxVPrice)
-    labelTargetPriceV.set_yloc(yloc.price)
-    labelTargetPriceV.set_text("V=" + str.format("{0, number, #.##}", t.boxVPrice))
+        labelTargetPriceV.set_x(t.boxTime1)
+        labelTargetPriceV.set_y(t.boxVPrice)
+        labelTargetPriceV.set_yloc(yloc.price)
+        labelTargetPriceV.set_text("V=" + str.format("{0, number, #.##}", t.boxVPrice))
 
-    if t.pWave == false
+    if t.pWave == false and t.sWave == false
         labelTargetPriceNt.set_x(t.boxTime1)
         labelTargetPriceNt.set_y(t.boxNtPrice)
         labelTargetPriceNt.set_yloc(yloc.price)
@@ -335,8 +369,24 @@ drawIndicator(Wave t) =>
         labelTargetPriceP.set_y(t.boxPPrice)
         labelTargetPriceP.set_yloc(yloc.price)
         labelTargetPriceP.set_text("P=" + str.format("{0, number, #.##}", t.boxPPrice))
+
+    if t.sWave
+        labelTargetPriceY.set_x(t.boxTime1)
+        labelTargetPriceY.set_y(t.boxYPrice)
+        labelTargetPriceY.set_yloc(yloc.price)
+        labelTargetPriceY.set_text("Y=" + str.format("{0, number, #.##}", t.boxYPrice))
+
+        labelTargetPriceS.set_x(t.boxTime1)
+        labelTargetPriceS.set_y(t.boxSPrice)
+        labelTargetPriceS.set_yloc(yloc.price)
+        labelTargetPriceS.set_text("S=" + str.format("{0, number, #.##}", t.boxSPrice))
+
+        labelTargetPriceSm.set_x(t.boxTime1)
+        labelTargetPriceSm.set_y(t.boxSmPrice)
+        labelTargetPriceSm.set_yloc(yloc.price)
+        labelTargetPriceSm.set_text("Sm=" + str.format("{0, number, #.##}", t.boxSmPrice))
         
-    if mult
+    if mult and t.sWave == false
         labelTargetPrice2E.set_x(t.boxTime1)
         labelTargetPrice2E.set_y(t.boxTopPrice2)
         labelTargetPrice2E.set_yloc(yloc.price)
@@ -377,12 +427,19 @@ drawIndicator(Wave t) =>
         labelTargetPrice5N.set_yloc(yloc.price)
         labelTargetPrice5N.set_text("5N=" + str.format("{0, number, #.##}", t.boxTopPrice5 - (t.boxTopPrice - t.price4)))
 
-    // If Point D has been placed after Point C, we have some prediction to make
+    // Point D is only labeled if positionned after Time C
     if t.timeD > t.time3
-        box.new(t.boxTimeE0, t.boxPriceEBot, t.boxTimeE1, t.boxPriceETop, bgcolor = color.rgb(0,0,0,100), border_color = color.aqua, xloc = xloc.bar_time, border_width = 1)
-        line.new(t.timeD, t.priceD, t.boxTimeE0, t.boxPriceETop, xloc=xloc.bar_time, color=color.aqua, style = line.style_arrow_right, width=1)
-        line.new(t.timeD, t.priceD, t.boxTimeE1, t.boxPriceETop, xloc=xloc.bar_time, color=color.aqua, style = line.style_arrow_right, width=1)
         label.new(t.timeD, t.priceD, "D\n" + str.format("{0, number, ###}", 1 + ((t.timeD - t.time1) / nb_seconds / 1000)) + (labp ? "\n" + str.format("{0, number, #.##}", t.priceD) : ""), xloc.bar_time, yloc.price, pointFillColor, styleABC2, pointTextColor, size.small, text.align_center)
+        // Trendlines are drawable since D is visible
+        if tren
+            line.new(t.time1, t.price1, t.time3, t.price3, xloc=xloc.bar_time, color=tcol, style = line.style_solid, width=1, extend = extend.both)
+            line.new(t.time2, t.price2, t.timeD, t.priceD, xloc=xloc.bar_time, color=tcol, style = line.style_solid, width=1, extend = extend.both)
+
+    // E-Box: If Point D has been placed after Point C, we have some prediction to make
+    if ebox and t.timeD > t.time3
+        box.new(t.boxTimeE0, t.boxPriceEBot, t.boxTimeE1, t.boxPriceETop, bgcolor = color.rgb(0,0,0,100), border_color = ecol, xloc = xloc.bar_time, border_width = 1)
+        line.new(t.timeD, t.priceD, t.boxTimeE0, t.boxPriceETop, xloc=xloc.bar_time, color=ecol, style = line.style_arrow_right, width=1)
+        line.new(t.timeD, t.priceD, t.boxTimeE1, t.boxPriceETop, xloc=xloc.bar_time, color=ecol, style = line.style_arrow_right, width=1)
         labelTargetPriceETop.set_x(t.boxTimeE1)
         labelTargetPriceETop.set_y(t.boxPriceETop)
         labelTargetPriceETop.set_yloc(yloc.price)
@@ -402,9 +459,15 @@ drawIndicator(Wave t) =>
         if t.priceD < t.price3
             labelBeforeTargetETime.set_style(label.style_label_down)
             labelAfterTargetETime.set_style(label.style_label_down)
-        if tren
-            line.new(t.time1, t.price1, t.time3, t.price3, xloc=xloc.bar_time, color=color.green, style = line.style_solid, width=1, extend = extend.both)
-            line.new(t.time2, t.price2, t.timeD, t.priceD, xloc=xloc.bar_time, color=color.green, style = line.style_solid, width=1, extend = extend.both)
+
+    if ksob and kisu == false
+        int pointB = t.time2 - (nb_seconds * 1000)
+        int[] cycles = array.from(9,17,26,33,42,51,65,76,83,97,101,151,226)
+        for i = array.size(cycles) - 1 to 0
+            if array.get(cycles, i) <= ksmx 
+                cycle = (array.get(cycles, i) * nb_seconds * 1000) + pointB
+                line.new(cycle, math.min(y1Input, y2Input, y3Input), cycle, math.max(y1Input, y2Input, y3Input), xloc.bar_time, extend.both, color.blue, line.style_solid, 2)
+                label.new(cycle, t.price2, str.format("{0, number, ##}", array.get(cycles, i)), xloc.bar_time, yloc.price, color.rgb(27, 32, 36, 100), label.style_label_left, color.blue )
 
     if fibo
         var offsetXFiboM = (nb_seconds * 1000 * fiboBarOffset) + t.time2
@@ -534,26 +597,32 @@ if barstate.islastconfirmedhistory
     wave.price1 := y1Input
     wave.price2 := y2Input
     wave.price3 := y3Input
-    wave.price4 := y3Input + (y2Input - y1Input)                                // N:   
+    wave.price4 := y3Input + (y2Input - y1Input)                                                                              // N:   
     wave.priceD := y4Input
-    wave.pWave  := ((wave.price1 > wave.price2 and wave.price3 < wave.price1 and wave.priceD > wave.price2) or (wave.price2 > wave.price1 and wave.price3 > wave.price1 and wave.priceD < wave.price2)) ? true : false
-    wave.yWave  := ((wave.price1 > wave.price2 and wave.price3 > wave.price1 and wave.priceD < wave.price2) or (wave.price2 > wave.price1 and wave.price3 < wave.price1 and wave.priceD > wave.price2)) ? true : false
-    wave.nWave  := (wave.pWave or wave.yWave) ? false : true
-    wave.lineColor := color.rgb(255, 255, 255, 66)
-    wave.arrowColor1 := color.orange
-    wave.arrowColor2 := color.blue
-    wave.arrowColor3 := color.rgb(255, 82, 102)
-    wave.arrowColor4 := color.green
+    wave.baNegative := wave.price1 > wave.price2                                                                              // (B-A) < 0   (A is higher than B)
+    wave.retracement := math.abs((wave.price2 - wave.price3) / (wave.price2 - wave.price1) * 100.0)
+    wave.nWave  := wave.retracement <= pret ? true : false                                                        // N Wave is a P Wave with less than 50% retracement (will tend to have D outside of AB)
+    wave.pWave  := wave.retracement > pret and wave.retracement < 100.0 ? true : false                            // P Wave is an N Wave with more than 50% retracement (will tend to have D staying inside of AB)
+    wave.sWave  := wave.retracement >= 100.0 ? true : false                                                                   // S Wave is the premice of a Y Wave with more than 100% of retracement on AB
+    wave.lineColor := color.rgb(255, 255, 255, 66)                                                                          // ABCD joints
+    wave.arrowColorNS := color.orange                                                                                       // N/S  
+    wave.arrowColorEY := color.blue                                                                                         // E/Y  
+    wave.arrowColorVSm := color.rgb(255, 82, 102)                                                                           // V/Sm
+    wave.arrowColorNtP := color.green                                                                                       // Nt/P
     wave.priceDelta1 := y2Input - y1Input
     wave.priceDelta2 := y3Input - y2Input
     wave.timeDelta1 := x2Input - x1Input
     wave.timeDelta2 := x3Input - x2Input
     wave.boxTime0 := wave.time4 - wave.timeDelta2
     wave.boxTime1 := wave.time4 + wave.timeDelta2
-    wave.boxTopPrice := (wave.price2 - wave.price1) + wave.price2               // E:  BD = AB
-    wave.boxVPrice := (wave.price2 - wave.price3) + wave.price2                 // V:  CD = BC
-    wave.boxNtPrice := (wave.price3 - wave.price1) + wave.price3                // Nt: CD = AC (need 33% retracement of BC over AB)
-    wave.boxPPrice := (wave.price1 - wave.price3) + wave.price2                 // P:  CD = B + (A - C)
+    wave.boxEPrice := (wave.price2 - wave.price1) + wave.price2                                                                 // E:  BD = AB
+    wave.boxVPrice := (wave.price2 - wave.price3) + wave.price2                                                                 // V:  CD = BC
+    wave.boxNtPrice := (wave.price3 - wave.price1) + wave.price3                                                                // Nt: CD = AC (need 33% retracement of BC over AB)
+    wave.boxPPrice := (wave.price1 - wave.price3) + wave.price2                                                                 // P:  CD = B + (A - C)
+    wave.boxYPrice := (wave.price1 - wave.price3) + wave.price2                                                                 // Y:  CD = B + (A - C)
+    wave.boxSPrice := (wave.price2 - wave.price1) + wave.price3                                                                 // S:  CD = C + (B - A)
+    wave.boxSmPrice := (0.5 * (wave.price2 - wave.price3)) + wave.price3                                                        // Sm: CD = C + ((B - C) / 2)
+    wave.boxTopPrice := wave.sWave ? wave.boxYPrice : wave.boxEPrice                                                            // Y if S-Wave or (E if N-Wave|P-Wave)
     wave.boxTopPrice2 := 2 * (wave.price4 - wave.price3) + (wave.boxTopPrice - wave.price4) + wave.price3
     wave.boxTopPrice3 := 3 * (wave.price4 - wave.price3) + (wave.boxTopPrice - wave.price4) + wave.price3
     wave.boxTopPrice4 := 4 * (wave.price4 - wave.price3) + (wave.boxTopPrice - wave.price4) + wave.price3
@@ -583,11 +652,13 @@ if barstate.islastconfirmedhistory
     wave.boxTimeE1 := (wave.timeD - wave.time1) + wave.timeD
     wave.barWidthInPixels := math.abs(bar_index - bar_index[1])
 
+    log.info(str.format("{0, number, #.##}", wave.retracement) + "% retracement, nWave is " + str.tostring(wave.nWave) + ", pWave is " + str.tostring(wave.pWave) + ", sWave is " + str.tostring(wave.sWave))
+
     drawIndicator(wave)
 
 if barstate.islast
     
-    if kisu
+    if kisu or ksob
         table.cell(tab, 0, 0, "Kihon Suchi 9, 17, 26, 33, 42, 51, 65, 76,,,", 17, 3, text_color = color.yellow, text_size = size.small, bgcolor = color.rgb(61, 61, 61))
 
 // Ichimoku stuff
@@ -618,11 +689,12 @@ if crss and barstate.islastconfirmedhistory
                 label.new(v, na, "⬅ " + str.format("{0, number, ###}", d), xloc.bar_index, yloc.abovebar, color.rgb(255, 0, 0), label.style_arrowdown, color.rgb(117, 188, 255), size.normal)
 
     // Kihon Suchi Cycles
-    if kisu
+    if kisu and ksob == false
         int[] cycles = array.from(9,17,26,33,42,51,65,76,83,97,101,151,226)
         for i = array.size(cycles) - 1 to 0
-            cycle = array.get(cycles, i) + lastCrossBar
-            line.new(cycle, math.min(y1Input, y2Input, y3Input), cycle, math.max(y1Input, y2Input, y3Input), xloc.bar_index, extend.none, color.yellow, line.style_dotted, 1)
+            if array.get(cycles, i) <= ksmx 
+                cycle = array.get(cycles, i) + lastCrossBar
+                line.new(cycle, math.min(y1Input, y2Input, y3Input), cycle, math.max(y1Input, y2Input, y3Input), xloc.bar_index, extend.none, color.yellow, line.style_dotted, 1)
         line.new(lastCrossover + lastCrossoverDist, math.min(y1Input, y2Input, y3Input), lastCrossover + lastCrossoverDist, math.max(y1Input, y2Input, y3Input), xloc.bar_index, extend.none, color.rgb(255, 217, 0), line.style_dashed, 1)
 
 // EMA

--- a/KOndulat.pine
+++ b/KOndulat.pine
@@ -1,7 +1,7 @@
 //@version=5
 indicator("Kir Ondulatoire", shorttitle="KOndulat", overlay=true)
 
-    // version 0.9.3
+    // version 0.9.4
 
     // Copyright (C) 2024  Kir
 
@@ -32,7 +32,7 @@ y3Input = input.price(PRICE_DEFAULT, "",        inline = "3", tooltip = "Pick po
 mult = input.bool(defval=false, title="Multiples E/N", inline="option1", group="Miscellaneous options")
 fibo = input.bool(defval=false, title="Fibonacci Axis", inline="option2", group="Miscellaneous options")
 tend = input.bool(defval=false, title="Stupid Linear Dir", inline="option3", group="Miscellaneous options")
-kisu = input.bool(defval=false, title="Kihon Sushi reminder", inline="option4", group="Miscellaneous options")
+kisu = input.bool(defval=false, title="Kihon Sushi reminder", inline="option4", group="Miscellaneous options", tooltip = "Need Tenkan crossovers to be displayed to add predictions")
 ichi = input.bool(defval=false, title="Draw Ichimoku", inline="option5", group="Miscellaneous options")
 crss = input.bool(defval=false, title="Display Tenkan Crossover Cycles", inline="option6", group="Miscellaneous options")
 dema = input.bool(defval=false, title="Draw EMA", inline="options7", group="Miscellaneous options")
@@ -86,7 +86,7 @@ conversionPeriods = input.int(9, minval=1, title="Conversion Line Length", group
 basePeriods = input.int(26, minval=1, title="Base Line Length", group="Ichimoku")
 laggingSpan2Periods = input.int(52, minval=1, title="Leading Span B Length", group="Ichimoku")
 displacement = input.int(26, minval=1, title="Lagging Span", group="Ichimoku")
-MaxLabels = input.int(5, minval=1, title="Maximum Crossover Labels", group="Ichimoku", tooltip = "An indicator is limited in the allowed amount of labels to draw. Keep this value low enough to prevent having lost labels.")
+MaxLabels = input.int(15, minval=1, title="Maximum Crossover Labels", group="Ichimoku", tooltip = "An indicator is limited in the allowed amount of labels to draw. Keep this value low enough to prevent having lost labels.")
 conversionLine = donchian(conversionPeriods)
 baseLine = donchian(basePeriods)
 leadLine1 = math.avg(conversionLine, baseLine)
@@ -499,13 +499,27 @@ fill(p1, p2, color = leadLine1 > leadLine2 ? color.rgb(67, 160, 71, 90) : color.
 // Display of the Tenkan Crossover Gaps
 if crss and barstate.islastconfirmedhistory
 
+    lastCrossover = array.get(crossoverBars, array.size(crossoverBars) - 1)
+    lastCrossoverDist = array.get(crossoverDist, array.size(crossoverBars) - 1)
+
     // Print the list of crossover bars and distances
     for i = array.size(crossoverBars) - 1 to 0
         int v = array.get(crossoverBars, i)
         int d = array.get(crossoverDist, i)
         labelCount := labelCount + 1
-        if labelCount <= 5
-            label.new(v, na, "⬅ " + str.format("{0, number, ###}", d), xloc.bar_index, yloc.abovebar, color.rgb(255, 0, 0), label.style_arrowdown, color.rgb(117, 188, 255), size.normal)
+        if labelCount <= MaxLabels
+            if i == array.size(crossoverBars) - 1
+                label.new(v, na, "⬅ " + str.format("{0, number, ###}", d) + "\n→" + str.format("{0, number, ###}", 1 + bar_index - lastCrossover), xloc.bar_index, yloc.abovebar, color.rgb(255, 0, 0), label.style_arrowdown, color.rgb(117, 188, 255), size.normal)
+            else    
+                label.new(v, na, "⬅ " + str.format("{0, number, ###}", d), xloc.bar_index, yloc.abovebar, color.rgb(255, 0, 0), label.style_arrowdown, color.rgb(117, 188, 255), size.normal)
+
+    // Kihon Suchi Cycles
+    if kisu
+        int[] cycles = array.from(9,17,26,33,42,51,65,76)
+        for i = array.size(cycles) - 1 to 0
+            cycle = array.get(cycles, i) + lastCrossBar
+            line.new(cycle, math.min(y1Input, y2Input, y3Input), cycle, math.max(y1Input, y2Input, y3Input), xloc.bar_index, extend.none, color.yellow, line.style_dotted, 1)
+        line.new(lastCrossover + lastCrossoverDist, math.min(y1Input, y2Input, y3Input), lastCrossover + lastCrossoverDist, math.max(y1Input, y2Input, y3Input), xloc.bar_index, extend.none, color.rgb(255, 217, 0), line.style_dashed, 1)
 
 // EMA
 out = ta.ema(src, len)

--- a/KOndulat.pine
+++ b/KOndulat.pine
@@ -33,7 +33,7 @@ y4Input = input.price(PRICE_DEFAULT, "",        inline = "4", tooltip = "Pick po
 
 pret = input.float(defval=50.0, title="% Retracement for a P-Wave", inline="option1", group="Wave options", tooltip="By default, a P wave is forming if the move BC retraced more than 50% of AB. N waves are more certain between 33% and 50%. Alter this if you think the situation is blurry.")
 mult = input.bool(defval=false, title="Multiples of E/N waves", inline="option2", group="Wave options", tooltip="Won't work in case of an S-Wave")
-ebox = input.bool(defval=false, title="E-Box", inline="option3", group="Wave options", tooltip="Need the point D to be placed after time C")
+ebox = input.bool(defval=true, title="E-Box", inline="option3", group="Wave options", tooltip="Need the point D to be placed after time C [STILL BUGGED AT THE MOMENT].")
 ecol = input.color(defval=color.aqua, title=" ", inline="option3", group="Wave options")
 tend = input.bool(defval=false, title="Straight Linear Projection", inline="option4", group="Wave options", tooltip="As long as the TARGET TIME is not reached, a purple arrow will point to the target. A purple label will give the estimated target price. It's a silly feature.")
 labp = input.bool(defval=false, title="Price in labels", inline="option5", group="Wave options")
@@ -97,6 +97,7 @@ type Wave
     float boxSmPrice
     float boxPriceETop
     float boxPriceEBot
+    float boxPriceEAnchor
     float currentPrice
     float midADPrice
     int   currentTime
@@ -427,8 +428,8 @@ drawIndicator(Wave t) =>
     // E-Box: If Point D has been placed after Point C, we have some prediction to make
     if ebox and t.timeD > t.time3
         box.new(t.boxTimeE0, t.boxPriceEBot, t.boxTimeE1, t.boxPriceETop, bgcolor = color.rgb(0,0,0,100), border_color = ecol, xloc = xloc.bar_time, border_width = 1)
-        line.new(t.timeD, t.priceD, t.boxTimeE0, t.boxPriceETop, xloc=xloc.bar_time, color=ecol, style = line.style_arrow_right, width=1)
-        line.new(t.timeD, t.priceD, t.boxTimeE1, t.boxPriceETop, xloc=xloc.bar_time, color=ecol, style = line.style_arrow_right, width=1)
+        line.new(t.timeD, t.priceD, t.boxTimeE0, t.boxPriceEAnchor, xloc=xloc.bar_time, color=ecol, style = line.style_arrow_right, width=1)
+        line.new(t.timeD, t.priceD, t.boxTimeE1, t.boxPriceEAnchor, xloc=xloc.bar_time, color=ecol, style = line.style_arrow_right, width=1)
         labelTargetPriceETop.set_x(t.boxTimeE1)
         labelTargetPriceETop.set_y(t.boxPriceETop)
         labelTargetPriceETop.set_yloc(yloc.price)
@@ -574,6 +575,28 @@ if barstate.isrealtime and not barstate.isconfirmed
     
     drawSLP(wave)
 
+closestLevel(bool baNegative, float d, float n, float e, float n2, float e2) => 
+    float level = 0
+    if baNegative == false
+        if d>n
+            level := d-n
+        if d>e
+            level := d-e
+        if d>n2
+            level := d-n2
+        if d>e2
+            level := d-e2
+    if baNegative
+        if d<n
+            level := n-d
+        if d<e
+            level := e-d
+        if d<n2
+            level := n2-d
+        if d<e2
+            level := e2-d
+    level
+
 // Draw the indicator on next confirmed tick
 if barstate.islastconfirmedhistory
 
@@ -617,33 +640,17 @@ if barstate.islastconfirmedhistory
     wave.boxTopPrice3 := 3 * (wave.price4 - wave.price3) + (wave.boxTopPrice - wave.price4) + wave.price3
     wave.boxTopPrice4 := 4 * (wave.price4 - wave.price3) + (wave.boxTopPrice - wave.price4) + wave.price3
     wave.boxTopPrice5 := 5 * (wave.price4 - wave.price3) + (wave.boxTopPrice - wave.price4) + wave.price3
-    wave.midADPrice := (math.abs(wave.priceD - wave.price1) * 0.5) + math.min(wave.price1, wave.priceD)                         // FIXME not really AD mid, have to find low and high of A,B,C,D
+    float halfADPrice = 0.5 * (math.max(wave.price1, wave.price2, wave.price3, wave.priceD) - math.min(wave.price1, wave.price2, wave.price3, wave.priceD))   // ABCD median (relative)
+    wave.midADPrice := wave.baNegative ? wave.price1 - halfADPrice : wave.price1 + halfADPrice                                                                // ABCD mid point (absolute)
+    // log.info(str.format("{0, number, #.####}", wave.midADPrice))
     wave.boxPriceEBot := wave.midADPrice
-    float proxy = wave.boxTopPrice                                              // FIXME please do way better than this
-    if (wave.priceD > wave.price4)
-        proxy := wave.price4
-    if (wave.priceD > wave.boxTopPrice)
-        proxy := wave.boxTopPrice
-    if (wave.priceD > (wave.boxTopPrice2 - (wave.boxTopPrice - wave.price4)))
-        proxy := (wave.boxTopPrice2 - (wave.boxTopPrice - wave.price4))
-    wave.boxPriceETop := wave.boxPriceEBot + (wave.priceD - proxy)             // Bot + (D - 2N or D - E or D - N)
-    if wave.priceD < wave.midADPrice
-        if (wave.priceD < wave.price4)
-            proxy := wave.price4
-        if (wave.priceD < wave.boxTopPrice)
-            proxy := wave.boxTopPrice
-        if (wave.priceD < (wave.boxTopPrice2 - (wave.boxTopPrice - wave.price4)))
-            proxy := (wave.boxTopPrice2 - (wave.boxTopPrice - wave.price4))
-        wave.boxPriceETop := wave.boxPriceEBot - math.abs(wave.priceD - proxy)             // Bot + (D - 2N or D - E or D - N)        
-        // float temp = wave.boxPriceETop
-        // wave.boxPriceETop := wave.boxPriceEBot
-        // wave.boxPriceEBot := temp
+    float deltaEN = wave.boxTopPrice - wave.price4
+    wave.boxPriceETop := wave.boxPriceEBot + closestLevel(wave.baNegative, wave.priceD, wave.price4, wave.boxTopPrice, wave.boxTopPrice2 - deltaEN, wave.boxTopPrice2)
     wave.boxTimeE0 := (wave.timeD - wave.time3) + wave.timeD
     wave.boxTimeE1 := (wave.timeD - wave.time1) + wave.timeD
+    wave.boxPriceEAnchor := wave.baNegative ? wave.priceD + math.min(wave.boxPriceEBot - wave.priceD, wave.boxPriceETop - wave.priceD) : wave.priceD + math.max(wave.boxPriceEBot - wave.priceD, wave.boxPriceETop - wave.priceD)
     wave.barWidthInPixels := math.abs(bar_index - bar_index[1])
-
-    log.info(str.format("{0, number, #.##}", wave.retracement) + "% retracement, nWave is " + str.tostring(wave.nWave) + ", pWave is " + str.tostring(wave.pWave) + ", sWave is " + str.tostring(wave.sWave))
-
+    // log.info(str.format("{0, number, #.##}", wave.retracement) + "% retracement, nWave is " + str.tostring(wave.nWave) + ", pWave is " + str.tostring(wave.pWave) + ", sWave is " + str.tostring(wave.sWave))
     drawIndicator(wave)
 
 if barstate.islast

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The **V arrow** is what the market would have done if the sign of BC had been re
 The indicator loses his relevance when the **Retracement BC** is lower than 33%.
 Above that, arrows **N, V, E** and **NT** can still reveal potential targets.
 
-When the market is strongly bullish or bearish, it's not unusual to watch the price go crazy above or below the window. In such cases, the chart may follow a strength arrow that is a multiple of **E** or **N**. That's why this script has an option to display those multiples as new attractive targets. 
+When the market is strongly bullish or bearish, it's not unusual to watch the price go crazy above or below the window. In such cases, the chart may follow a strength arrow that is a multiple of **E** or **N**. That's why this script has an option to display those multiples as new attractive targets. Take notes that 5E/5N are irrational targets.
 
 The **SLP** stands for **Stupid Linear Prediction**. It's really just the direction the chart is heading into from the C point to now (now being the last confirmed bar). It has no real value. The calculated value shown in the purple label is the market price this chart would end up at if continuing in that direction, up to the **Target Time**.
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Pine script for Trading View about an Hosoda N-Wave indicator
 ![Fibonacci Axis](https://github.com/Kirken2004/tv-kir-ondulat/blob/main/preview_fibonacci_axis_retracements.jpg?raw=true)
 <p align="center">fig. 2 - The Fibonacci Axis and the Retracements</p>
 
-![Ichimoku Kynko Hyo and EMA](https://github.com/Kirken2004/tv-kir-ondulat/blob/main/preview_ichimoku_ema.jpg?raw=true)
-<p align="center">fig. 3 - Ichimoku Kynko Hyo, Clouds and the EMA 200</p>
+![Ichimoku Kinko Hyo and EMA](https://github.com/Kirken2004/tv-kir-ondulat/blob/main/preview_ichimoku_ema.jpg?raw=true)
+<p align="center">fig. 3 - Ichimoku Kinko Hyo, Clouds and the EMA 200</p>
 
 ![Kihon Suchi and Tenkan Crossover Cycles](https://github.com/Kirken2004/tv-kir-ondulat/blob/main/preview_kihon_suchi_tenkan_crossovers.jpg?raw=true)
 <p align="center">fig. 4 - Kihon Suchi and Tenkan Crossover Cycles</p>

--- a/README.md
+++ b/README.md
@@ -78,11 +78,12 @@ If BC is atleast 33% of AB, it's fair to assume the price is going to turn in th
 The **N arrow** is merely AB drawn again from C. 
 That hypothetical D pointed by the N arrow is at the **Target Time** (sometimes called the **N time**, or even **N Target**).
 
-The **Target Time** is in a window in which the value is not supposed to be drastically changing, once the current bar gets inside. The duration of the window is inferred by the BC duration. The right side of the window is usually predicting the end of a structure, and a period where a new one is building up.
+The **Target Time** is in a window, a box, in which the value is supposed to evolve or solidify the current structure move. The left side of the box is time 1, and the middle dashed line is the time 2. Once the current bar gets inside, you know the time component of the action. Yet you'll have to discover the price it goes to. The duration of the window is inferred by the BC duration. The right side of the window (time 3) is usually the beginning of a new wave building up, or a continuation you had to confirm.
 
-A reddish dashed line named the **Decision Line** is drawn away from BC, at the same distance from C. This dashed line is at a moment in time when you may want to check the rightness of the predictions. If the candles follow the arrows and dont change direction before this stage, the window is still a potential target for the N Wave. If the candles went completly elsewhere, you probably misplaced your ABC points. Or the market just went crazy, like it often does (sic).
+A reddish dashed line named the **Correlation Line** is drawn away from BC, at the same distance from C. This dashed line is at a moment in time when you may want to check the rightness of the predictions. If the candles follow the arrows and dont change direction before this stage, the window is still a potential target for the N Wave. If the candles went completly elsewhere, you probably misplaced your ABC points. Or the market just went crazy, like it often does (sic). 
+If the line is before or after time 2 by one period, you may determine a correlation with the Ichimoku numbers (ie. Kihon Suchi series).
 
-The indicator is helpful at the time it is drawn until the candles gets into the window. It wont move over time. Whatever the market is doing, once on the other side of the **decision line**, this instance of the indicator becomes a thing of the past. If you made a plan using it, stick to the plan. And play it safe if the market tries something unexpected in that window. 
+The indicator is helpful at the time it is drawn until the candles gets into the window. It wont move over time. Whatever the market is doing, once on the other side of the **Correlation Line**, this instance of the indicator becomes a thing of the past. If you made a plan using it, stick to the plan. And play it safe if the market tries something unexpected in that window. 
 
 The **E arrow** is what the market would have done if not stopped at B. But delayed by the BC time. 
 
@@ -101,7 +102,12 @@ I also added a feature called **Tenkan Crossover Markers**. An arrow is displaye
 
 The **Kihon Suchi** series describe a typical number of bars after which the Tenkan sen crosses over the Kijun sen. It's theory. And prone to errors by 2 due to the nature of bars in a timeframe. After the last crossing, one can expect to see the next one following that series. I added this indicator for fun. The dashed gold line is not on the series. It shows the bar in the future that correspond to the same cycle than the last one. The numbers of the series can be displayed at the bottom center of the chart. 
 
-At the moment, this indicator is tedious to use on several charts at once. You may require one layout(tab) per chart. Switching between symbols is not working. I wish i could draw several instances of this indicator on one chart. I'm pretty sure you'll find a comfy way to use it anyhow. 
+At the moment, this indicator is tedious to use on several charts at once : 
+    - You may require one layout(tab) per chart. 
+    - Switching between symbols is not working. 
+    - I wish i could draw several instances of this indicator on one chart without any trouble. 
+    - Dont check every option at once, you'll lose elements past 50 ones on the chart per indicator. 
+I'm pretty sure you'll find a comfy way to use it anyhow. 
 
 
 ## F.A.Q.
@@ -151,6 +157,13 @@ No. Probably not. I'll get bored very quickly on that subject.
         - Fibonacci retracement [https://en.wikipedia.org/wiki/Fibonacci_retracement]
         - Ichimoku Kinkō Hyō [https://en.wikipedia.org/wiki/Ichimoku_Kink%C5%8D_Hy%C5%8D]
 
+    - TradingView
+
+        - IKH Wave Theory Introduction and Indicator Basics [https://www.tradingview.com/chart/BTCUSD/NHqEe3Qk-Ichimoku-Kink%C5%8D-Hy%C5%8D-Wave-Theory-Introduction-and-Indicator-Basics/]
+
+    - XTB.com (French)
+
+        - Ichimoku: quel est cet indicateur ? [https://www.xtb.com/fr/formation/ichimoku]
 
 
 ## Contact

--- a/README.md
+++ b/README.md
@@ -90,14 +90,14 @@ The **NT arrow** is almost the opposite, it's what the market would have done at
 
 The **V arrow** is what the market would have done if the sign of BC had been reversed. 
 
-The indicator loses his relevance when the **Retracement BC** is lower than 33%.
+The indicator loses some of its relevance when the **Retracement BC** is lower than 33%.
 Above that, arrows **N, V, E** and **NT** can still reveal potential targets.
 
 When the market is strongly bullish or bearish, it's not unusual to watch the price go crazy above or below the window. In such cases, the chart may follow a strength arrow that is a multiple of **E** or **N**. That's why this script has an option to display those multiples as new attractive targets. Take notes that 5E/5N are irrational targets.
 
-The **SLP** stands for **Stupid Linear Prediction**. It's really just the direction the chart is heading into from the C point to now (now being the last confirmed bar). It has no real value. The calculated value shown in the purple label is the market price this chart would end up at if continuing in that direction, up to the **Target Time**.
+The **SLP** stands for **Straight Linear Projection**. It's really just the direction the chart is heading into from the C point to now (now being the last confirmed bar). It has no real value. The calculated value shown in the purple label is the market price this chart would end up at if continuing in that direction, up to the **Target Time**.
 
-I also added a feature called **Tenkan Crossover Cycles**. An arrow is displayed above bars where a Tenkan crossing over the Kijun happened. The numerical value indicate the number of bars since the last event of that kind occured on the left. When the tenkan is crossing over, it's often accompanied by a movement up or down of the price. It's a change in the structure itself.
+I also added a feature called **Tenkan Crossover Markers**. An arrow is displayed above bars when a Tenkan crossed over the Kijun. The numerical value indicate the number of bars since the last event of that kind occured on the left. When the tenkan is crossing over, it's often accompanied by a movement up or down of the price. It's a change in the structure itself. It's important to follow those crossovers. 
 
 The **Kihon Suchi** series describe a typical number of bars after which the Tenkan sen crosses over the Kijun sen. It's theory. And prone to errors by 2 due to the nature of bars in a timeframe. After the last crossing, one can expect to see the next one following that series. I added this indicator for fun. The dashed gold line is not on the series. It shows the bar in the future that correspond to the same cycle than the last one. The numbers of the series can be displayed at the bottom center of the chart. 
 
@@ -134,6 +134,10 @@ No. Probably not. I'll get bored very quickly on that subject.
         - Ichimoku Kinko Hyo Part 3 [https://www.youtube.com/watch?v=iKyue8rugmw]
         - Ichimoku Kinko Hyo Part 4 [https://www.youtube.com/watch?v=4HJgaYwahyg]
         - Ichimoku Kinko Hyo Part 5 [https://www.youtube.com/watch?v=fM4s_piN-Ps]
+
+    - ChaosTrader63's channel (English)
+
+        - Trading Ichimoku Kinko Hyo Three Roles With Wave, Price, & Time Theories [https://www.youtube.com/watch?v=CIjWEsr0Cgo]
 
     - ZS Trader's Masterclasses (French)
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ When the market is strongly bullish or bearish, it's not unusual to watch the pr
 
 The **SLP** stands for **Stupid Linear Prediction**. It's really just the direction the chart is heading into from the C point to now (now being the last confirmed bar). It has no real value. The calculated value shown in the purple label is the market price this chart would end up at if continuing in that direction, up to the **Target Time**.
 
+I also added a feature called **Tenkan Crossover Cycles**. An arrow is displayed above bars where a Tenkan crossing over the Kijun happened. The numerical value indicate the number of bars since the last event of that kind occured on the left. When the tenkan is crossing over, it's often accompanied by a movement up or down of the price. It's a change in the structure itself.
+
+The **Kihon Suchi** series describe a typical number of bars after which the Tenkan sen crosses over the Kijun sen. It's theory. And prone to errors by 2 due to the nature of bars in a timeframe. After the last crossing, one can expect to see the next one following that series. I added this indicator for fun. The dashed gold line is not on the series. It shows the bar in the future that correspond to the same cycle than the last one. The numbers of the series can be displayed at the bottom center of the chart. 
+
 At the moment, this indicator is tedious to use on several charts at once. You may require one layout(tab) per chart. Switching between symbols is not working. I wish i could draw several instances of this indicator on one chart. I'm pretty sure you'll find a comfy way to use it anyhow. 
 
 

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -2,16 +2,22 @@ VERSION HISTORY
 
     v0.9.4 - 03-24-2024
 
-        - added P Target as B + (A - C), instead of an Nt one, displayed when having a P Wave structure using A/B/C/D
-        - added a window for a point E wave based on CLogik's approach using a potentially realised D point
+        - added the case of A/B/C is the beginning of an S-wave (more than 100% of BC retracement over AB)
+        - added P Target as B + (A - C), instead of an Nt one, displayed when having a P-wave structure using A/B/C/D (>50% retracement)
+        - added an option to specify the % of retracement needed for a P-wave (N-wave and P-wave have a blurry area)
+        - added a box to point E based on CLogik's approach using a potentially realised D point (many bugs if not in a positive N-Wave)
         - added an option to add the price to the label at each A/B/C/D point
-        - added timeframes to the Kihon Suchi series
+        - added vertical extended lines to the Kihon Suchi series
+            o can start from the last tenkan crossover/crossunder time (as period 1 in the series)
+            o can start from B time (as period 1 in the series)
         - added an option to draw the A/B/C/D trendlines (D has to be visible)
         - added an option to draw the A+26 periods dateline (and the C+26 one)
         - found a gremlin who messed with the calculus of the multiples of N and E arrows
-        - fixed an oopsie on the Tenkan Crossover limiting amount of labels and reduced the default max amount
-        - fixed the number of bars between A and B and C (the number in the above the bar label was not including A in the count)
-        - fixes and typos
+        - fixed an oopsie on the Tenkan Crossover limiting amount of labels 
+        - fixed the limitation of the total amount of labels displayed by the indicator to 100
+        - fixed the number of bars between A and B and C (the number in the "above the bar" label was not including A in the count)
+        - fixes and many typos
+        - removed dead code
 
     v0.9.3 - 03-23-2024
 

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,13 +1,15 @@
 VERSION HISTORY
 
-    v0.9.4 - 03-24-2024
+    v0.9.4 - 04-06-2024
 
-        - added the case of A/B/C is the beginning of an S-wave (more than 100% of BC retracement over AB)
-        - added P Target as B + (A - C), instead of an Nt one, displayed when having a P-wave structure using A/B/C/D (>50% retracement)
-        - added an option to specify the % of retracement needed for a P-wave (N-wave and P-wave have a blurry area)
-        - added a box to point E based on CLogik's approach using a potentially realised D point (many bugs if not in a positive N-Wave)
+        - added the case of A/B/C is the beginning of an S-Wave (more than 100% of BC retracement over AB)
+        - added P Target as B + (A - C), instead of an Nt one, displayed when having a P-Wave structure using A/B/C/D (>50% retracement)
+        - added an option to specify the % of retracement needed for a P-Wave (N-Wave and P-Wave have a blurry area)
+        - added a box to point E based on CLogik's approach using a potentially realised D point : 
+            o still has many bugs if not in a positive N-Wave,
+            o and it won't display anything within an S-Wave
         - added an option to add the price to the label at each A/B/C/D point
-        - added vertical extended lines to the Kihon Suchi series
+        - added vertical extended lines to the Kihon Suchi series that : 
             o can start from the last tenkan crossover/crossunder time (as period 1 in the series)
             o can start from B time (as period 1 in the series)
         - added an option to draw the A/B/C/D trendlines (D has to be visible)

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -3,6 +3,10 @@ VERSION HISTORY
     v0.9.4 - 03-24-2024
 
         - fixed an oopsie on the Tenkan Crossover amount of labels limiter
+        - fixed the number of bars between A and B and C (the number in the above the bar label was not including A in the count)
+        - added P Target as B + (A - C)
+        - found a gremlins who messed with the calculus of the multiples of N and E
+        - added a prediction for an E Wave based on ZS's approach
 
     v0.9.3 - 03-23-2024
 

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,5 +1,9 @@
 VERSION HISTORY
 
+    v0.9.4 - 03-24-2024
+
+        - fixed an oopsie on the Tenkan Crossover amount of labels limiter
+
     v0.9.3 - 03-23-2024
 
         - fixes and typos

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -2,11 +2,16 @@ VERSION HISTORY
 
     v0.9.4 - 03-24-2024
 
-        - fixed an oopsie on the Tenkan Crossover amount of labels limiter
+        - added P Target as B + (A - C), instead of an Nt one, displayed when having a P Wave structure using A/B/C/D
+        - added a window for a point E wave based on CLogik's approach using a potentially realised D point
+        - added an option to add the price to the label at each A/B/C/D point
+        - added timeframes to the Kihon Suchi series
+        - added an option to draw the A/B/C/D trendlines (D has to be visible)
+        - added an option to draw the A+26 periods dateline (and the C+26 one)
+        - found a gremlin who messed with the calculus of the multiples of N and E arrows
+        - fixed an oopsie on the Tenkan Crossover amount of labels limiter and reduced the default max amount
         - fixed the number of bars between A and B and C (the number in the above the bar label was not including A in the count)
-        - added P Target as B + (A - C)
-        - found a gremlins who messed with the calculus of the multiples of N and E
-        - added a prediction for an E Wave based on ZS's approach
+        - fixes and typos
 
     v0.9.3 - 03-23-2024
 

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -9,7 +9,7 @@ VERSION HISTORY
         - added an option to draw the A/B/C/D trendlines (D has to be visible)
         - added an option to draw the A+26 periods dateline (and the C+26 one)
         - found a gremlin who messed with the calculus of the multiples of N and E arrows
-        - fixed an oopsie on the Tenkan Crossover amount of labels limiter and reduced the default max amount
+        - fixed an oopsie on the Tenkan Crossover limiting amount of labels and reduced the default max amount
         - fixed the number of bars between A and B and C (the number in the above the bar label was not including A in the count)
         - fixes and typos
 
@@ -20,7 +20,7 @@ VERSION HISTORY
     v0.9.2 - 03-19-2024
 
         - changed the SLP arrow to a realtime direction arrow ending up on TARGET TIME
-        - SLP arrow disappear past the TARGET TIME
+        - SLP arrow now disappears past the TARGET TIME
         - removed the VERSION.txt file that was only used internally
         - Added a hint option for people in need of the Kihon Suchi cycles
         - Added the built-in Ichimoku indicator as an integrated option


### PR DESCRIPTION
    v0.9.4 - 04-06-2024

        - added the case of A/B/C is the beginning of an S-Wave (more than 100% of BC retracement over AB)
        - added P Target as B + (A - C), instead of an Nt one, displayed when having a P-Wave structure using A/B/C/D (>50% retracement)
        - added an option to specify the % of retracement needed for a P-Wave (N-Wave and P-Wave have a blurry area)
        - added a box to point E based on CLogik's approach using a potentially realised D point : 
            o still has many bugs if not in a positive N-Wave,
            o and it won't display anything within an S-Wave
        - added an option to add the price to the label at each A/B/C/D point
        - added vertical extended lines to the Kihon Suchi series that : 
            o can start from the last tenkan crossover/crossunder time (as period 1 in the series)
            o can start from B time (as period 1 in the series)
        - added an option to draw the A/B/C/D trendlines (D has to be visible)
        - added an option to draw the A+26 periods dateline (and the C+26 one)
        - found a gremlin who messed with the calculus of the multiples of N and E arrows
        - fixed an oopsie on the Tenkan Crossover limiting amount of labels 
        - fixed the limitation of the total amount of labels displayed by the indicator to 100
        - fixed the number of bars between A and B and C (the number in the "above the bar" label was not including A in the count)
        - fixes and many typos
        - removed dead code